### PR TITLE
34 Enable `/black` in comments

### DIFF
--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -1,0 +1,26 @@
+name: chatops
+
+# currently dispatches /black command to project-monai/monai-code-formatter
+on:
+  issue_comment:
+    types: [created, edited]
+jobs:
+  dispatch_command:
+    runs-on: ubuntu-latest
+    steps:
+      - name: dispatch
+        uses: peter-evans/slash-command-dispatch@v1.2.0
+        with:
+          token: ${{ secrets.PR_MAINTAIN }}
+          reaction-token: ${{ secrets.GITHUB_TOKEN }}
+          reactions: false
+          config: >
+            [
+              {
+                "command": "black",
+                "permission": "none",
+                "issue_type": "pull-request",
+                "allow_edits": true,
+                "repository": "project-monai/monai-code-formatter"
+              }
+            ]


### PR DESCRIPTION
Fixes #34 .

### Description
This PR is used to add a workflow that can enable `/black` in comments to fix format issues automatically.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
