### PR TITLE
41 Customized verify tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,7 +57,6 @@ We prepared several premerge CI tests to verify your bundle.
 ### Necessary verifications
 
 1. Check if `configs/metadata.json` is existing in your bundle.
-1. Check if `models/model.pt` is existing in your bundle or in `large_files.yml` (or `.yaml`, `.json`)
 1. If an existing bundle has been modified, check if `version` and `changelog` are updated.
 1. Check if metadata format is correct. You can also run the following command locally to verify your bundle before submitting a pull request:
 
@@ -74,7 +73,7 @@ Check if the input and output data shape and data type of network defined in the
 python -m monai.bundle verify_net_in_out --net_id network_def --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle) of the config file to get the network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include them into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works for the torchscript test that will be mentioned bellow.
+`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle) of the config file to get the network definition. The default values in the CI tests are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include them into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works for the torchscript test that will be mentioned bellow.
 
 If this test is not suitable for your bundle, please add your bundle name into `exclude_verify_shape_list` in `ci/bundle_custom_data.py`.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ Check if the input and output data shape and data type of network defined in the
 python -m monai.bundle verify_net_in_out --net_id network_def --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle) of the config file to get network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include your customized values into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works on the torchscript test that will be mentioned bellow.
+`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle) of the config file to get the network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include them into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works for the torchscript test that will be mentioned bellow.
 
 If this test is not suitable for your bundle, please add your bundle name into `exclude_verify_shape_list` in `ci/bundle_custom_data.py`.
 
@@ -90,7 +90,7 @@ If your bundle does not support TorchScript, please mention it in `docs/README.m
 
 ## Checking the coding style
 
-After Verifying your bundle, if there are any `.py` files, coding style is checked and enforced by flake8, black, isort, pytype and mypy.
+After verifying your bundle, if there are any `.py` files, coding style is checked and enforced by flake8, black, isort, pytype and mypy.
 Before submitting a pull request, we recommend that all checks should pass, by running the following command locally:
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,8 @@ python -m monai.bundle verify_metadata --meta_file configs/metadata.json --filep
 
 ### Optional verifications
 
-1. Check if the input and output data shape and data type of network defined in the metadata are correct. You can also run the following command locally to verify your bundle before submitting a pull request.
+#### Verify data shape and data type
+Check if the input and output data shape and data type of network defined in the metadata are correct. You can also run the following command locally to verify your bundle before submitting a pull request.
 
 ```bash
 python -m monai.bundle verify_net_in_out --net_id network_def --meta_file configs/metadata.json --config_file configs/inference.json
@@ -78,7 +79,8 @@ of the config file to get network definition. The default values are `network_de
 
 If this test is not suitable for your bundle, please add your bundle name into `exclude_verify_shape_list` in `ci/bundle_custom_data.py`.
 
-1. Check the functionality of exporting the checkpoint to TorchScript file. You can also run the following command locally to verify your bundle before submitting a pull request.
+#### Verify torchscript
+Check the functionality of exporting the checkpoint to TorchScript file. You can also run the following command locally to verify your bundle before submitting a pull request.
 
 ```bash
 python -m monai.bundle ckpt_export --net_id network_def --filepath models/verify_model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,37 +42,50 @@ The template is as follow, and you can also click [here](https://github.com/Proj
 
 ```
 large_files:
-  - path: "models/large-file-1.pt"
-    url: "url-of-large-file-1.pt"
+  - path: "models/model.pt"
+    url: "url-of-model.pt"
     hash_val: ""
     hash_type: ""
-  - path: "models/large-file-2.ts"
-    url: "url-of-large-file-2.ts"
+  - path: "models/model.ts"
+    url: "url-of-model.ts"
 ```
 
 ## Verifying the bundle
 
-After preparing your bundle, we recommend that both the metadata format and the data shape of network are verified, by running the following command locally:
+We prepared several premerge CI tests to verify your bundle.
+
+### Necessary verifications
+
+1. Check if `configs/metadata.json` is existing in your bundle.
+1. Check if `models/model.pt` is existing in your bundle or in `large_files.yml` (or `.yaml`, `.json`)
+1. If an existing bundle has been modified, check if `version` and `changelog` are updated.
+1. Check if metadata format is correct. You can also run the following command locally to verify your bundle before submitting a pull request:
 
 ```bash
-# Verify the metadata format
 python -m monai.bundle verify_metadata --meta_file configs/metadata.json --filepath eval/schema.json
-
-# Verify the data shape of network
-# Please modify the suffix of the config file if `.json` is not used
-python -m monai.bundle verify_net_in_out network_def --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-## Export checkpoint to TorchScript file
+### Optional verifications
 
-For a bundle that support TorchScript, the following command is used to export your checkpoint into TorchScript file:
+1. Check if the input and output data shape and data type of network defined in the metadata are correct. You can also run the following command locally to verify your bundle before submitting a pull request.
 
 ```bash
-# Please modify the suffix of the config file if `.json` is not used
-python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
+python -m monai.bundle verify_net_in_out --net_id network_def --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-If your bundle does not support TorchScript, please mention it in `docs/README.md`.
+`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle)
+of the config file to get network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include your customized values into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works on the torchscript test that will be mentioned bellow.
+
+If this test is not suitable for your bundle, please add your bundle name into `exclude_verify_shape_list` in `ci/bundle_custom_data.py`.
+
+1. Check the functionality of exporting the checkpoint to TorchScript file. You can also run the following command locally to verify your bundle before submitting a pull request.
+
+```bash
+python -m monai.bundle ckpt_export --net_id network_def --filepath models/verify_model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
+```
+
+If your bundle does not support TorchScript, please mention it in `docs/README.md`, and add your bundle name into `exclude_verify_torchscript_list` in `ci/bundle_custom_data.py`.
+
 
 ## Checking the coding style
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,8 +74,7 @@ Check if the input and output data shape and data type of network defined in the
 python -m monai.bundle verify_net_in_out --net_id network_def --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle)
-of the config file to get network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include your customized values into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works on the torchscript test that will be mentioned bellow.
+`net_id` is the ID name of the network component, `config_file` is the filepath (within the bundle) of the config file to get network definition. The default values are `network_def` for `net_id` and `configs/inference.json` for `config_file`, if different values are used, please include your customized values into `custom_net_config_dict` in `ci/bundle_custom_data.py`. This requirement also works on the torchscript test that will be mentioned bellow.
 
 If this test is not suitable for your bundle, please add your bundle name into `exclude_verify_shape_list` in `ci/bundle_custom_data.py`.
 

--- a/ci/bundle_custom_data.py
+++ b/ci/bundle_custom_data.py
@@ -10,10 +10,8 @@
 # limitations under the License.
 
 
-# please add the bundle name into the following list if it does not need to verify data input and output shape.
 exclude_verify_shape_list = []
 
-# please add the bundle name into the following list if it does not support torchscript.
 exclude_verify_torchscript_list = ["swin_unetr_btcv_segmentation"]
 
 # please add the bundle (as a key) and a dict in the form of {"net_id": "", "config_file": ""} (as a value)

--- a/ci/bundle_custom_data.py
+++ b/ci/bundle_custom_data.py
@@ -16,14 +16,6 @@ exclude_verify_shape_list = []
 # please add the bundle name into the following list if it does not support torchscript.
 exclude_verify_torchscript_list = ["swin_unetr_btcv_segmentation"]
 
-"""
-To verify the input and output data shape and data type of network defined in the metadata,
-"net_id" and "config_file" are two arguments that need to input.
-"net_id" is the ID name of the network component, "config_file" is the filepath (within the bundle)
-of the config file to get network definition.
-The default values are "network_def" for "net_id" and "configs/inference.json" for "config_file",
-if different values are used, please add the bundle (as a key) and a dict in the form of
-{"net_id": "", "config_file": ""} (as a value) into the follow dict.
-
-"""
+# please add the bundle (as a key) and a dict in the form of {"net_id": "", "config_file": ""} (as a value)
+# into the following dict.
 custom_net_config_dict = {"pancreas_ct_dints_segmentation": {"config_file": "configs/inference.yaml"}}

--- a/ci/bundle_custom_data.py
+++ b/ci/bundle_custom_data.py
@@ -1,0 +1,31 @@
+# Copyright (c) MONAI Consortium
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from typing import Dict, List
+
+# please add the bundle name into the following list if it does not need to verify data input and output shape.
+exclude_verify_shape_list: List = []
+
+# please add the bundle name into the following list if it does not support torchscript.
+exclude_verify_torchscript_list: List = ["swin_unetr_btcv_segmentation"]
+
+"""
+To verify the input and output data shape and data type of network defined in the metadata,
+"net_id" and "config_file" are two arguments that need to input.
+"net_id" is the ID name of the network component, "config_file" is the filepath (within the bundle)
+of the config file to get network definition.
+The default values are "network_def" for "net_id" and "configs/inference.json" for "config_file",
+if different values are used, please add the bundle (as a key) and a dict in the form of
+{"net_id": "", "config_file": ""} (as a value) into the follow dict.
+
+"""
+custom_net_config_dict: Dict = {"pancreas_ct_dints_segmentation": {"config_file": "configs/inference.yaml"}}

--- a/ci/bundle_custom_data.py
+++ b/ci/bundle_custom_data.py
@@ -10,10 +10,19 @@
 # limitations under the License.
 
 
+# This list is used for our CI tests to determine whether a bundle needs to be tested with
+# the `verify_data_shape` function in `verify_bundle.py`.
+# If a bundle does not need to be tested, please add the bundle name into the list.
 exclude_verify_shape_list = []
 
+# This list is used for our CI tests to determine whether a bundle needs to be tested with
+# the `verify_export_torchscript` function in `verify_bundle.py`.
+# If a bundle does not support TorchScript, please add the bundle name into the list.
 exclude_verify_torchscript_list = ["swin_unetr_btcv_segmentation"]
 
-# please add the bundle (as a key) and a dict in the form of {"net_id": "", "config_file": ""} (as a value)
+# This dict is used for our CI tests to override the values of the arguments "net_id" and "config_file"
+# for the `verify_data_shape` and `verify_export_torchscript` functions.
+# The default values are "network_def" for "net_id" and `configs/inference.json` for `config_file`.
+# please add the bundle name (as a key) and a dict in the form of {"net_id": "", "config_file": ""} (as a value)
 # into the following dict.
 custom_net_config_dict = {"pancreas_ct_dints_segmentation": {"config_file": "configs/inference.yaml"}}

--- a/ci/bundle_custom_data.py
+++ b/ci/bundle_custom_data.py
@@ -10,13 +10,11 @@
 # limitations under the License.
 
 
-from typing import Dict, List
-
 # please add the bundle name into the following list if it does not need to verify data input and output shape.
-exclude_verify_shape_list: List = []
+exclude_verify_shape_list = []
 
 # please add the bundle name into the following list if it does not support torchscript.
-exclude_verify_torchscript_list: List = ["swin_unetr_btcv_segmentation"]
+exclude_verify_torchscript_list = ["swin_unetr_btcv_segmentation"]
 
 """
 To verify the input and output data shape and data type of network defined in the metadata,
@@ -28,4 +26,4 @@ if different values are used, please add the bundle (as a key) and a dict in the
 {"net_id": "", "config_file": ""} (as a value) into the follow dict.
 
 """
-custom_net_config_dict: Dict = {"pancreas_ct_dints_segmentation": {"config_file": "configs/inference.yaml"}}
+custom_net_config_dict = {"pancreas_ct_dints_segmentation": {"config_file": "configs/inference.yaml"}}

--- a/ci/update_model_info.py
+++ b/ci/update_model_info.py
@@ -81,12 +81,11 @@ def update_model_info(
     model_info_path = os.path.join(models_path, model_info_file)
     model_info = get_json_dict(model_info_path)
 
-    if bundle_name not in model_info.keys():
-        model_info[bundle_name] = {"version": "", "checksum": "", "source": ""}
+    if bundle_zip_name not in model_info.keys():
+        model_info[bundle_zip_name] = {"checksum": "", "source": ""}
 
-    model_info[bundle_name]["checksum"] = checksum
-    model_info[bundle_name]["version"] = latest_version
-    model_info[bundle_name]["source"] = source
+    model_info[bundle_zip_name]["checksum"] = checksum
+    model_info[bundle_zip_name]["source"] = source
 
     save_model_info(model_info, model_info_path)
     return (True, "update successful")

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -145,11 +145,6 @@ def main(changed_dirs):
     1. according to changed directories, get changed bundles.
     2. verify each bundle.
 
-    The verifications include necessary tests and optional tests.
-    Necessary tests contain the functions: `verify_version_changes` and `verify_metadata_format`.
-    Optional tests contain the functions: `verify_download_large_files`, `verify_data_shape` and
-    `verify_export_torchscript`.
-
     """
     bundle_list = get_changed_bundle_list(changed_dirs)
     models_path = "models"

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -120,18 +120,10 @@ def get_net_id_config_name(bundle_name: str):
     """
     Return values of arguments net_id and config_file.
     """
-    net_id = "network_def"
-    config_file = "configs/inference.json"
-    if bundle_name not in custom_net_config_dict.keys():
-        return net_id, config_file
 
-    name_dict = custom_net_config_dict[bundle_name]
-    if "net_id" in name_dict.keys():
-        net_id = name_dict["net_id"]
-    if "config_file" in name_dict.keys():
-        config_file = name_dict["config_file"]
+    name_dict = custom_net_config_dict.get(bundle_name, {})
 
-    return net_id, config_file
+    return name_dict.get("net_id", "network_def"), name_dict.get("config_file", "configs/inference.json")
 
 
 def main(changed_dirs):
@@ -147,13 +139,17 @@ def main(changed_dirs):
 
     if len(bundle_list) > 0:
         for bundle in bundle_list:
+            print(f"start verifying {bundle}:")
             # verify bundle directory
             verify_bundle_directory(models_path, bundle)
+            print("directory is verified correctly.")
             # verify version, changelog
             verify_version_changes(models_path, bundle)
+            print("version and changelog are verified correctly.")
             # verify metadata format and data
             bundle_path = os.path.join(models_path, bundle)
             verify_metadata_format(bundle_path)
+            print("metadata format is verified correctly.")
 
             # The following are optional tests
             net_id, config_file = get_net_id_config_name(bundle)
@@ -162,10 +158,12 @@ def main(changed_dirs):
                 print(f"skip verifying the data shape of bundle: {bundle}.")
             else:
                 verify_data_shape(bundle_path, net_id, config_file)
+                print("data shape is verified correctly.")
             if bundle in exclude_verify_torchscript_list:
                 print(f"bundle: {bundle} does not support torchscript, skip verifying.")
             else:
                 verify_export_torchscript(bundle_path, net_id, config_file)
+                print("Exporting TorchScript is verified correctly.")
     else:
         print(f"all changed files: {changed_dirs} are not related to any existing bundles, skip verifying.")
 

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -121,6 +121,9 @@ def verify_export_torchscript(bundle_path: str, net_id: str, config_file: str):
 
 
 def get_net_id_config_name(bundle_name: str):
+    """
+    Return values of arguments net_id and config_file.
+    """
     net_id = "network_def"
     config_file = "configs/inference.json"
     if bundle_name not in custom_net_config_dict.keys():

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -20,8 +20,8 @@ from utils import download_large_files, get_changed_bundle_list, get_json_dict
 def verify_bundle_directory(models_path: str, bundle_name: str):
     """
     According to [MONAI Bundle Specification](https://docs.monai.io/en/latest/mb_specification.html),
-    "configs/metadata.json" and "models/model.pt" are required within the bundle root directory.
-    This function is used to verify these files. For bundles that contain the download links for large
+    "configs/metadata.json" is required within the bundle root directory.
+    This function is used to verify this file. For bundles that contain the download links for large
     files, the links should be saved in "large_files.yml" (or .json, .yaml).
     All large files (if exist) will be downloaded before verification.
 
@@ -42,10 +42,6 @@ def verify_bundle_directory(models_path: str, bundle_name: str):
     metadata_path = os.path.join(bundle_path, "configs/metadata.json")
     if not os.path.exists(metadata_path):
         raise ValueError(f"metadata path: {metadata_path} is not existing.")
-
-    model_path = os.path.join(bundle_path, "models/model.pt")
-    if not os.path.exists(model_path):
-        raise ValueError(f"model path: {model_path} is not existing.")
 
 
 def verify_version_changes(models_path: str, bundle_name: str):

--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "changelog": {
+        "0.1.1": "test",
         "0.1.0": "complete the model package"
     },
     "monai_version": "0.9.0",

--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,8 +1,7 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.1",
+    "version": "0.1.0",
     "changelog": {
-        "0.1.1": "test",
         "0.1.0": "complete the model package"
     },
     "monai_version": "0.9.0",

--- a/models/model_info.json
+++ b/models/model_info.json
@@ -1,31 +1,25 @@
 {
-    "spleen_deepedit_annotation": {
-        "version": "0.1.0",
+    "spleen_deepedit_annotation_v0.1.0.zip": {
         "checksum": "3ff10564f5ff359f2190f7055641c66b53a9489b",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/spleen_deepedit_annotation_v0.1.0.zip"
     },
-    "pancreas_ct_dints_segmentation": {
-        "version": "0.1.0",
+    "pancreas_ct_dints_segmentation_v0.1.0.zip": {
         "checksum": "ab22f3ef8cc7bf4e95394644c4563cb89766687f",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/pancreas_ct_dints_segmentation_v0.1.0.zip"
     },
-    "brats_mri_segmentation": {
-        "version": "0.1.0",
+    "brats_mri_segmentation_v0.1.0.zip": {
         "checksum": "878735f655cd3e498c65bacee2522160b250dcce",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/brats_mri_segmentation_v0.1.0.zip"
     },
-    "spleen_ct_segmentation": {
-        "version": "0.1.0",
+    "spleen_ct_segmentation_v0.1.0.zip": {
         "checksum": "18bae0a62d90fb06b33c1c7702867a4d4d7b98f0",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/spleen_ct_segmentation_v0.1.0.zip"
     },
-    "swin_unetr_btcv_segmentation": {
-        "version": "0.1.0",
+    "swin_unetr_btcv_segmentation_v0.1.0.zip": {
         "checksum": "56d4089c4039b8f145c234f0d2ef31748f5ad8ba",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/swin_unetr_btcv_segmentation_v0.1.0.zip"
     },
-    "ventricular_short_axis_3label": {
-        "version": "0.1.0",
+    "ventricular_short_axis_3label_v0.1.0.zip": {
         "checksum": "adbbd30e8efbc8c4253f73c965bd30f129f2589b",
         "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/ventricular_short_axis_3label_v0.1.0.zip"
     }


### PR DESCRIPTION
Fixes #42 and #41 .

### Description
This PR is used to:

1. add a verify function to check "version" and "changelog" in the metadata file.
1. add a verify function to check if necessary files (models/model.pt and configs/metadata.json) are included.
1. let contributors be able to exclude optional tests (verify torchscript and data shape) that are not suitable for their bundles.
1. modify the format of `model_info.json`, where a key is consistent with the compressed file name in release. Otherwise, the json file will only contain the latest version of each bundle.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
