### PR TITLE
80 Add bundle path for ci test

### DIFF
--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -11,6 +11,7 @@
 
 import argparse
 import os
+import sys
 
 import torch
 from bundle_custom_data import custom_net_config_dict, exclude_verify_shape_list, exclude_verify_torchscript_list
@@ -139,6 +140,8 @@ def verify(bundle):
 
     models_path = "models"
     print(f"start verifying {bundle}:")
+    # add bundle path to ensure custom code can be used
+    sys.path = [os.path.join(models_path, bundle)] + sys.path
     # verify bundle directory
     verify_bundle_directory(models_path, bundle)
     print("directory is verified correctly.")


### PR DESCRIPTION
Fixes #80 .

### Description
This PR adds bundle path for ci test, thus the customized code can be recognized.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`