### PR TITLE
103 Add suggestions for the format of "path"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,3 +14,4 @@ A few sentences describing the changes proposed in this pull request.
 - [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
 - [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
 - [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
+- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,10 @@ Please refer to [MONAI Bundle Specification](https://docs.monai.io/en/latest/mb_
 
 The [get started](https://github.com/Project-MONAI/tutorials/blob/main/modules/bundle/get_started.ipynb) notebook is a step-by-step tutorial to help developers easily get started to develop a bundle. And [bundle examples](https://github.com/Project-MONAI/tutorials/tree/main/modules/bundle) show the typical bundle for 3D segmentation, how to use customized components in a bundle, and how to parse bundle in your own program as "hybrid" mode, etc.
 
+As for the path related varibles within config files (such as "bundle_root"), we suggest to use path that do not include personal information (such as `"/home/your_name/"`).The following is an example of path using:
+
+`"bundle_root": "/workspace/data/<bundle name>"`.
+
 ### Readme Format
 
 A [template](https://github.com/Project-MONAI/model-zoo/blob/dev/docs/readme_template.md) on how to prepare a readme file is provided.


### PR DESCRIPTION
Fixes #103 .

### Description
This PR is used to add suggestions for the format of "path" used in config files. The suggestions are added into the contribution guide and the PR checkboxes

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json`.
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
