### PR TITLE
107 Fix brats bundle metadata error

### DIFF
--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "changelog": {
+        "0.2.1": "fix network_data_format error",
         "0.2.0": "unify naming",
         "0.1.1": "update for MetaTensor",
         "0.1.0": "complete the model package"
@@ -45,13 +46,13 @@
                     "8*n"
                 ],
                 "dtype": "float32",
-                "value_range": [
-                    0,
-                    1
-                ],
+                "value_range": [],
                 "is_patch_data": true,
                 "channel_def": {
-                    "0": "image"
+                    "0": "T1c",
+                    "1": "T1",
+                    "2": "T2",
+                    "3": "FLAIR"
                 }
             }
         },
@@ -72,8 +73,9 @@
                 ],
                 "is_patch_data": true,
                 "channel_def": {
-                    "0": "background",
-                    "1": "spleen"
+                    "0": "Tumor core",
+                    "1": "Whole tumor",
+                    "2": "Enhancing tumor"
                 }
             }
         }


### PR DESCRIPTION
Fixes #107 .

### Description
The `network_data_format` part of the `brats_mri_segmentation` bundle is wrongly described, this PR is used to fix it.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [x] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [x] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
