### PR TITLE
156 split loader and saver from processing

### DIFF
--- a/models/spleen_ct_segmentation/configs/inference.json
+++ b/models/spleen_ct_segmentation/configs/inference.json
@@ -104,7 +104,7 @@
             "keys": "pred",
             "meta_keys": "pred_meta_dict",
             "output_dir": "@output_dir"
-        }  
+        }
     ],
     "post_transforms": [
         {

--- a/models/spleen_ct_segmentation/configs/inference.json
+++ b/models/spleen_ct_segmentation/configs/inference.json
@@ -8,6 +8,8 @@
     "dataset_dir": "/workspace/data/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
+    "use_loader": true,
+    "use_saver": true,
     "network_def": {
         "_target_": "UNet",
         "spatial_dims": 3,
@@ -30,46 +32,49 @@
         "norm": "batch"
     },
     "network": "$@network_def.to(@device)",
+    "default_loader": [
+        {
+            "_target_": "LoadImaged",
+            "keys": "image"
+        }
+    ],
+    "infer_transforms": [
+        {
+            "_target_": "EnsureChannelFirstd",
+            "keys": "image"
+        },
+        {
+            "_target_": "Orientationd",
+            "keys": "image",
+            "axcodes": "RAS"
+        },
+        {
+            "_target_": "Spacingd",
+            "keys": "image",
+            "pixdim": [
+                1.5,
+                1.5,
+                2.0
+            ],
+            "mode": "bilinear"
+        },
+        {
+            "_target_": "ScaleIntensityRanged",
+            "keys": "image",
+            "a_min": -57,
+            "a_max": 164,
+            "b_min": 0,
+            "b_max": 1,
+            "clip": true
+        },
+        {
+            "_target_": "EnsureTyped",
+            "keys": "image"
+        }
+    ],
     "preprocessing": {
         "_target_": "Compose",
-        "transforms": [
-            {
-                "_target_": "LoadImaged",
-                "keys": "image"
-            },
-            {
-                "_target_": "EnsureChannelFirstd",
-                "keys": "image"
-            },
-            {
-                "_target_": "Orientationd",
-                "keys": "image",
-                "axcodes": "RAS"
-            },
-            {
-                "_target_": "Spacingd",
-                "keys": "image",
-                "pixdim": [
-                    1.5,
-                    1.5,
-                    2.0
-                ],
-                "mode": "bilinear"
-            },
-            {
-                "_target_": "ScaleIntensityRanged",
-                "keys": "image",
-                "a_min": -57,
-                "a_max": 164,
-                "b_min": 0,
-                "b_max": 1,
-                "clip": true
-            },
-            {
-                "_target_": "EnsureTyped",
-                "keys": "image"
-            }
-        ]
+        "transforms": "$@default_loader + @infer_transforms if @use_loader else @infer_transforms"
     },
     "dataset": {
         "_target_": "Dataset",
@@ -93,35 +98,38 @@
         "sw_batch_size": 4,
         "overlap": 0.5
     },
+    "default_saver": [
+        {
+            "_target_": "SaveImaged",
+            "keys": "pred",
+            "meta_keys": "pred_meta_dict",
+            "output_dir": "@output_dir"
+        }  
+    ],
+    "post_transforms": [
+        {
+            "_target_": "Activationsd",
+            "keys": "pred",
+            "softmax": true
+        },
+        {
+            "_target_": "Invertd",
+            "keys": "pred",
+            "transform": "@preprocessing",
+            "orig_keys": "image",
+            "meta_key_postfix": "meta_dict",
+            "nearest_interp": false,
+            "to_tensor": true
+        },
+        {
+            "_target_": "AsDiscreted",
+            "keys": "pred",
+            "argmax": true
+        }
+    ],
     "postprocessing": {
         "_target_": "Compose",
-        "transforms": [
-            {
-                "_target_": "Activationsd",
-                "keys": "pred",
-                "softmax": true
-            },
-            {
-                "_target_": "Invertd",
-                "keys": "pred",
-                "transform": "@preprocessing",
-                "orig_keys": "image",
-                "meta_key_postfix": "meta_dict",
-                "nearest_interp": false,
-                "to_tensor": true
-            },
-            {
-                "_target_": "AsDiscreted",
-                "keys": "pred",
-                "argmax": true
-            },
-            {
-                "_target_": "SaveImaged",
-                "keys": "pred",
-                "meta_keys": "pred_meta_dict",
-                "output_dir": "@output_dir"
-            }
-        ]
+        "transforms": "$@post_transforms + @default_saver if @use_saver else @post_transforms"
     },
     "handlers": [
         {

--- a/models/spleen_ct_segmentation/configs/inference.json
+++ b/models/spleen_ct_segmentation/configs/inference.json
@@ -39,7 +39,7 @@
                 "_target_": "LoadImaged",
                 "keys": "image",
                 "_disabled_": "@disable_loader",
-                "_desc_": "the default image loader, if disabled, the preprocessing accepts data volume directly."
+                "_desc_": "the default image loader, if disabled, please preaper data volume and override dataset#data."
             },
             {
                 "_target_": "EnsureChannelFirstd",

--- a/models/spleen_ct_segmentation/configs/inference.json
+++ b/models/spleen_ct_segmentation/configs/inference.json
@@ -8,8 +8,8 @@
     "dataset_dir": "/workspace/data/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
-    "use_loader": true,
-    "use_saver": true,
+    "disable_loader": "false",
+    "disable_writer": "false",
     "network_def": {
         "_target_": "UNet",
         "spatial_dims": 3,
@@ -32,49 +32,48 @@
         "norm": "batch"
     },
     "network": "$@network_def.to(@device)",
-    "default_loader": [
-        {
-            "_target_": "LoadImaged",
-            "keys": "image"
-        }
-    ],
-    "infer_transforms": [
-        {
-            "_target_": "EnsureChannelFirstd",
-            "keys": "image"
-        },
-        {
-            "_target_": "Orientationd",
-            "keys": "image",
-            "axcodes": "RAS"
-        },
-        {
-            "_target_": "Spacingd",
-            "keys": "image",
-            "pixdim": [
-                1.5,
-                1.5,
-                2.0
-            ],
-            "mode": "bilinear"
-        },
-        {
-            "_target_": "ScaleIntensityRanged",
-            "keys": "image",
-            "a_min": -57,
-            "a_max": 164,
-            "b_min": 0,
-            "b_max": 1,
-            "clip": true
-        },
-        {
-            "_target_": "EnsureTyped",
-            "keys": "image"
-        }
-    ],
     "preprocessing": {
         "_target_": "Compose",
-        "transforms": "$@default_loader + @infer_transforms if @use_loader else @infer_transforms"
+        "transforms": [
+            {
+                "_target_": "LoadImaged",
+                "keys": "image",
+                "_disabled_": "@disable_loader",
+                "_desc_": "the default image loader, if disabled, the preprocessing accepts data volume directly."
+            },
+            {
+                "_target_": "EnsureChannelFirstd",
+                "keys": "image"
+            },
+            {
+                "_target_": "Orientationd",
+                "keys": "image",
+                "axcodes": "RAS"
+            },
+            {
+                "_target_": "Spacingd",
+                "keys": "image",
+                "pixdim": [
+                    1.5,
+                    1.5,
+                    2.0
+                ],
+                "mode": "bilinear"
+            },
+            {
+                "_target_": "ScaleIntensityRanged",
+                "keys": "image",
+                "a_min": -57,
+                "a_max": 164,
+                "b_min": 0,
+                "b_max": 1,
+                "clip": true
+            },
+            {
+                "_target_": "EnsureTyped",
+                "keys": "image"
+            }
+        ]
     },
     "dataset": {
         "_target_": "Dataset",
@@ -98,38 +97,37 @@
         "sw_batch_size": 4,
         "overlap": 0.5
     },
-    "default_saver": [
-        {
-            "_target_": "SaveImaged",
-            "keys": "pred",
-            "meta_keys": "pred_meta_dict",
-            "output_dir": "@output_dir"
-        }
-    ],
-    "post_transforms": [
-        {
-            "_target_": "Activationsd",
-            "keys": "pred",
-            "softmax": true
-        },
-        {
-            "_target_": "Invertd",
-            "keys": "pred",
-            "transform": "@preprocessing",
-            "orig_keys": "image",
-            "meta_key_postfix": "meta_dict",
-            "nearest_interp": false,
-            "to_tensor": true
-        },
-        {
-            "_target_": "AsDiscreted",
-            "keys": "pred",
-            "argmax": true
-        }
-    ],
     "postprocessing": {
         "_target_": "Compose",
-        "transforms": "$@post_transforms + @default_saver if @use_saver else @post_transforms"
+        "transforms": [
+            {
+                "_target_": "Activationsd",
+                "keys": "pred",
+                "softmax": true
+            },
+            {
+                "_target_": "Invertd",
+                "keys": "pred",
+                "transform": "@preprocessing",
+                "orig_keys": "image",
+                "meta_key_postfix": "meta_dict",
+                "nearest_interp": false,
+                "to_tensor": true
+            },
+            {
+                "_target_": "AsDiscreted",
+                "keys": "pred",
+                "argmax": true
+            },
+            {
+                "_target_": "SaveImaged",
+                "keys": "pred",
+                "meta_keys": "pred_meta_dict",
+                "output_dir": "@output_dir",
+                "_disabled_": "@disable_writer",
+                "_desc_": "the default image saver, if disabled, the inference results will not be saved."
+            }
+        ]
     },
     "handlers": [
         {

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "changelog": {
+        "0.3.3": "move load and save out of process",
         "0.3.2": "improve multi-gpu logging",
         "0.3.1": "add multi-gpu evaluation config",
         "0.3.0": "update license files",


### PR DESCRIPTION
Fixes #156 .

### Description
This PR modifies the inference script of `spleen_ct_segmentation` bundle via putting image load out of `preprocessing` and putting image save out of `postprocessing.`
a flag `use_loader` is used to determine if `LoadImaged` is included into `preprocessing`, and a flag `use_saver` is used to determine if `SaveImaged` is included into `postprocessing`.

After these changes:
- if users want to use the default settings, they do not need to change anything.
- if users want to load images by using other methods, but still use the `dataset` inside the script, they can specify `use_loader` to `False` and then override `dataset#data`, the following is an example:

![Screen Shot 2022-10-14 at 4 01 14 PM](https://user-images.githubusercontent.com/68361391/195794547-f9128fea-c443-404b-a334-fba8eecff155.png)

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
