### PR TITLE
180 Update bundles to support monai 1.0.1

### DIFF
--- a/models/brats_mri_segmentation/configs/evaluate.json
+++ b/models/brats_mri_segmentation/configs/evaluate.json
@@ -23,7 +23,7 @@
                 "threshold": 0.5
             },
             {
-                "_target_": "SplitChanneld",
+                "_target_": "SplitDimd",
                 "keys": [
                     "pred",
                     "label"

--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "changelog": {
+        "0.3.3": "update to use monai 1.0.1",
         "0.3.2": "enhance readme on commands example",
         "0.3.1": "fix license Copyright error",
         "0.3.0": "update license files",
@@ -10,12 +11,14 @@
         "0.1.1": "update for MetaTensor",
         "0.1.0": "complete the model package"
     },
-    "monai_version": "0.9.1",
-    "pytorch_version": "1.12.0",
+    "monai_version": "1.0.1",
+    "pytorch_version": "1.13.0",
     "numpy_version": "1.22.4",
     "optional_packages_version": {
         "nibabel": "4.0.1",
-        "pytorch-ignite": "0.4.9"
+        "pytorch-ignite": "0.4.9",
+        "scikit-learn": "1.1.3",
+        "tensorboard": "2.10.1"
     },
     "task": "Multimodal Brain Tumor segmentation",
     "description": "A pre-trained model for volumetric (3D) segmentation of brain tumor subregions from multimodal MRIs based on BraTS 2018 data",

--- a/models/brats_mri_segmentation/configs/train.json
+++ b/models/brats_mri_segmentation/configs/train.json
@@ -248,7 +248,7 @@
                     "threshold": 0.5
                 },
                 {
-                    "_target_": "SplitChanneld",
+                    "_target_": "SplitDimd",
                     "keys": [
                         "pred",
                         "label"

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -10,7 +10,7 @@ The model is trained to segment 3 nested subregions of primary brain tumors (gli
 
 ## Data
 
-The training data is from the [Multimodal Brain Tumor Segmentation Challenge (BraTS) 2018](https://www.med.upenn.edu/sbia/brats2018/data.html).
+The training data is from the [Multimodal Brain Tumor Segmentation Challenge (BraTS) 2018](https://www.med.upenn.edu/cbica/sbia/brats2018/tasks.html).
 
 - Target: 3 tumor subregions
 - Task: Segmentation

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.4",
+    "version": "0.3.5",
     "changelog": {
+        "0.3.5": "update to use monai 1.0.1",
         "0.3.4": "enhance readme on commands example",
         "0.3.3": "fix license Copyright error",
         "0.3.2": "improve multi-gpu logging",
@@ -12,12 +13,12 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.0.0",
-    "pytorch_version": "1.12.1",
+    "monai_version": "1.0.1",
+    "pytorch_version": "1.13.0",
     "numpy_version": "1.21.2",
     "optional_packages_version": {
-        "nibabel": "3.2.1",
-        "pytorch-ignite": "0.4.8"
+        "nibabel": "4.0.1",
+        "pytorch-ignite": "0.4.9"
     },
     "task": "Decathlon spleen segmentation",
     "description": "A pre-trained model for volumetric (3D) segmentation of the spleen from CT image",


### PR DESCRIPTION
Fixes #180  .

### Description
This PR is used to update `brats_mri_segmentation` and `spleen_ct_segmentation` bundles to support monai 1.0.1 and pytorch 1.13.0

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
