### PR TITLE
swin bundle for monai 1.0.1 and pytorch 1.13, num_sample change

### DIFF
--- a/models/swin_unetr_btcv_segmentation/configs/metadata.json
+++ b/models/swin_unetr_btcv_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "changelog": {
+        "0.3.3": "Update, verify MONAI 1.0.1 and Pytorch 1.13.0",
         "0.3.2": "enhance readme on commands example",
         "0.3.1": "fix license Copyright error",
         "0.3.0": "update license files",
@@ -9,8 +10,8 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "0.9.0",
-    "pytorch_version": "1.10.0",
+    "monai_version": "1.0.1",
+    "pytorch_version": "1.13.0",
     "numpy_version": "1.21.2",
     "optional_packages_version": {
         "nibabel": "3.2.1",

--- a/models/swin_unetr_btcv_segmentation/configs/train.json
+++ b/models/swin_unetr_btcv_segmentation/configs/train.json
@@ -106,7 +106,7 @@
                 ],
                 "pos": 1,
                 "neg": 1,
-                "num_samples": 4,
+                "num_samples": 2,
                 "image_key": "image",
                 "image_threshold": 0
             },
@@ -267,8 +267,8 @@
                 96,
                 96
             ],
-            "sw_batch_size": 4,
-            "overlap": 0.5
+            "sw_batch_size": 2,
+            "overlap": 0.25
         },
         "postprocessing": "%train#postprocessing",
         "handlers": [


### PR DESCRIPTION
Signed-off-by: tangy5 <yucheng.tang@vanderbilt.edu>

This is for updating swin_unetr_btcv_segmentation bundle for MONAI 1.0.1 and Pytorch 1.13.0.
Associate with https://github.com/Project-MONAI/model-zoo/issues/180

BTW, modified some default parameter to be "friendly" with MONAI Label usage, to reduce latency.