### PR TITLE
update val patch size in detection  to avoid warning

### DIFF
--- a/models/lung_nodule_ct_detection/configs/inference.json
+++ b/models/lung_nodule_ct_detection/configs/inference.json
@@ -16,7 +16,7 @@
     "val_patch_size": [
         512,
         512,
-        208
+        192
     ],
     "anchor_generator": {
         "_target_": "monai.apps.detection.utils.anchor_utils.AnchorGeneratorWithAnchorShape",

--- a/models/lung_nodule_ct_detection/configs/metadata.json
+++ b/models/lung_nodule_ct_detection/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "changelog": {
+        "0.4.3": "update val patch size to avoid warning in monai 1.0.1",
         "0.4.2": "update to use monai 1.0.1",
         "0.4.1": "fix license Copyright error",
         "0.4.0": "add support for raw images",

--- a/models/lung_nodule_ct_detection/configs/train.json
+++ b/models/lung_nodule_ct_detection/configs/train.json
@@ -23,7 +23,7 @@
     "val_patch_size": [
         512,
         512,
-        208
+        192
     ],
     "anchor_generator": {
         "_target_": "monai.apps.detection.utils.anchor_utils.AnchorGeneratorWithAnchorShape",


### PR DESCRIPTION
Signed-off-by: Can Zhao <canz@nvidia.com>

Fixes # .

### Description
update val patch size in detection  to fit 16g
avoid warning message from sliding window inferer

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
