### PR TITLE
use ITKreader

### DIFF
--- a/models/swin_unetr_btcv_segmentation/configs/inference.json
+++ b/models/swin_unetr_btcv_segmentation/configs/inference.json
@@ -23,7 +23,8 @@
         "transforms": [
             {
                 "_target_": "LoadImaged",
-                "keys": "image"
+                "keys": "image",
+                "reader": "ITKReader"
             },
             {
                 "_target_": "EnsureChannelFirstd",

--- a/models/swin_unetr_btcv_segmentation/configs/metadata.json
+++ b/models/swin_unetr_btcv_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "changelog": {
+        "0.3.9": "use ITKreader to avoid mass logs at image loading",
         "0.3.8": "restructure readme to match updated template",
         "0.3.7": "Update metric in metadata",
         "0.3.6": "Update ckpt drive link",

--- a/models/swin_unetr_btcv_segmentation/configs/train.json
+++ b/models/swin_unetr_btcv_segmentation/configs/train.json
@@ -41,7 +41,8 @@
                 "keys": [
                     "image",
                     "label"
-                ]
+                ],
+                "reader": "ITKReader"
             },
             {
                 "_target_": "EnsureChannelFirstd",


### PR DESCRIPTION
Use ITKreader in `LoadImaged` to avoid massive confused logs for correcting orientation. 