### PR TITLE
254 fix flake8 issue

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,8 @@ select = B,C,E,F,N,P,T4,W,B9
 max_line_length = 120
 # C408 ignored because we like the dict keyword argument syntax
 # E501 is not flexible enough, we're using B950 instead
+# N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
+# B023 https://github.com/Project-MONAI/MONAI/issues/4627
 ignore =
     E203
     E501
@@ -10,9 +12,10 @@ ignore =
     W503
     W504
     C408
-    N812  # lowercase 'torch.nn.functional' imported as non lowercase 'F'
+    N812
+    B023
 per_file_ignores = __init__.py: F401, __main__.py: F401
-exclude = *.pyi,.git,.eggs,versioneer.py,venv,.venv,_version.py
+exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 
 [isort]
 known_first_party = models


### PR DESCRIPTION
Fixes #254 .

### Description
This PR is used to fix the flake8 related issue..

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
