### PR TITLE
add a note for multi-gpu training of endoscopic inbody classification…

### DIFF
--- a/models/endoscopic_inbody_classification/configs/metadata.json
+++ b/models/endoscopic_inbody_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.3",
+    "version": "0.3.4",
     "changelog": {
+        "0.3.4": "add note for multi-gpu training with example dataset",
         "0.3.3": "enhance data preprocess script and readme file",
         "0.3.2": "restructure readme to match updated template",
         "0.3.1": "add workflow, train loss and validation accuracy figures",

--- a/models/endoscopic_inbody_classification/docs/README.md
+++ b/models/endoscopic_inbody_classification/docs/README.md
@@ -17,6 +17,11 @@ After downloading this dataset, python script in `scripts` folder named `data_pr
 python scripts/data_process.py --datapath /path/to/data/root
 ```
 
+>Note:
+> - If using the 20 samples example dataset, this preprocessing script will divide the samples to 16 training samples, 2 validation samples and 2 test samples.
+> - However, pytorch multi-gpu training requires number of samples in dataloader larger than gpu numbers.
+> - Therefore, please use no more than 2 gpus to run this bundle, if using the 20 samples example dataset.
+
 By default, label path parameter in `train.json` and `inference.json` of this bundle is point to the generated `label` folder under bundle path. If you move these generated label files to another place, please modify the `train_json`, `val_json` and `test_json` parameters specified in `configs/train.json` and `configs/inference.json` to where these label files are.
 
 The input label json should be a list made up by dicts which includes `image` and `label` keys. An example format is shown below.

--- a/models/endoscopic_inbody_classification/docs/README.md
+++ b/models/endoscopic_inbody_classification/docs/README.md
@@ -17,10 +17,10 @@ After downloading this dataset, python script in `scripts` folder named `data_pr
 python scripts/data_process.py --datapath /path/to/data/root
 ```
 
->Note:
+**Note:**
 > - If using the 20 samples example dataset, this preprocessing script will divide the samples to 16 training samples, 2 validation samples and 2 test samples.
 > - However, pytorch multi-gpu training requires number of samples in dataloader larger than gpu numbers.
-> - Therefore, please use no more than 2 gpus to run this bundle, if using the 20 samples example dataset.
+> - Therefore, please use no more than 2 gpus to run this bundle if using the 20 samples example dataset.
 
 By default, label path parameter in `train.json` and `inference.json` of this bundle is point to the generated `label` folder under bundle path. If you move these generated label files to another place, please modify the `train_json`, `val_json` and `test_json` parameters specified in `configs/train.json` and `configs/inference.json` to where these label files are.
 

--- a/models/endoscopic_inbody_classification/docs/README.md
+++ b/models/endoscopic_inbody_classification/docs/README.md
@@ -17,11 +17,6 @@ After downloading this dataset, python script in `scripts` folder named `data_pr
 python scripts/data_process.py --datapath /path/to/data/root
 ```
 
-**Note:**
-> - If using the 20 samples example dataset, this preprocessing script will divide the samples to 16 training samples, 2 validation samples and 2 test samples.
-> - However, pytorch multi-gpu training requires number of samples in dataloader larger than gpu numbers.
-> - Therefore, please use no more than 2 gpus to run this bundle if using the 20 samples example dataset.
-
 By default, label path parameter in `train.json` and `inference.json` of this bundle is point to the generated `label` folder under bundle path. If you move these generated label files to another place, please modify the `train_json`, `val_json` and `test_json` parameters specified in `configs/train.json` and `configs/inference.json` to where these label files are.
 
 The input label json should be a list made up by dicts which includes `image` and `label` keys. An example format is shown below.
@@ -96,6 +91,8 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run training
 ```
 
 Please note that the distributed training-related options depend on the actual running environment; thus, users may need to remove `--standalone`, modify `--nnodes`, or do some other necessary changes according to the machine used. For more details, please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
+
+In addition, if using the 20 samples example dataset, the preprocessing script will divide the samples to 16 training samples, 2 validation samples and 2 test samples. However, pytorch multi-gpu training requires number of samples in dataloader larger than gpu numbers. Therefore, please use no more than 2 gpus to run this bundle if using the 20 samples example dataset.
 
 #### Override the `train` config to execute evaluation with the trained model:
 


### PR DESCRIPTION
… bundle.

Signed-off-by: binliu <binliu@nvidia.com>

Fixes # .

### Description
Add a description for endoscopic inbody classification bundle for multi-gpu training.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
