### PR TITLE
234 Modify the title of auto created PR [skip gpu]

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -127,7 +127,7 @@ def push_new_model_info_branch(model_info_path: str):
     return branch_name
 
 
-def create_pull_request(branch_name: str, pr_title: str = "'auto update model_info'"):
+def create_pull_request(branch_name: str, pr_title: str = "'auto update model_info [skip ci]'"):
     create_command = f"gh pr create --fill --title {pr_title} --base dev --head {branch_name}"
     call_status = subprocess.run(create_command, shell=True)
     call_status.check_returncode()

--- a/ci/utils.py
+++ b/ci/utils.py
@@ -127,7 +127,7 @@ def push_new_model_info_branch(model_info_path: str):
     return branch_name
 
 
-def create_pull_request(branch_name: str, pr_title: str = "'auto update model_info [skip ci]'"):
+def create_pull_request(branch_name: str, pr_title: str = "'auto update model_info [skip gpu]'"):
     create_command = f"gh pr create --fill --title {pr_title} --base dev --head {branch_name}"
     call_status = subprocess.run(create_command, shell=True)
     call_status.check_returncode()

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -302,8 +302,6 @@ def verify(bundle, mode="full"):
     bundle_path = os.path.join(models_path, bundle)
     verify_metadata_format(bundle_path)
     print("metadata format is verified correctly.")
-    if mode == "min":
-        return
 
     # The following are optional tests
     net_id, inference_file_name = "network_def", _find_bundle_file(os.path.join(bundle_path, "configs"), "inference")
@@ -314,6 +312,10 @@ def verify(bundle, mode="full"):
     else:
         verify_data_shape(bundle_path, net_id, config_file)
         print("data shape is verified correctly.")
+    if mode == "min":
+        return
+
+    # The following tests require to use GPU
     if bundle in exclude_verify_torchscript_list:
         print(f"bundle: {bundle} does not support torchscript, skip verifying.")
     else:

--- a/ci/verify_bundle.py
+++ b/ci/verify_bundle.py
@@ -303,6 +303,9 @@ def verify(bundle, mode="full"):
     verify_metadata_format(bundle_path)
     print("metadata format is verified correctly.")
 
+    if mode == "min":
+        return
+
     # The following are optional tests
     net_id, inference_file_name = "network_def", _find_bundle_file(os.path.join(bundle_path, "configs"), "inference")
     config_file = os.path.join("configs", inference_file_name)
@@ -312,8 +315,6 @@ def verify(bundle, mode="full"):
     else:
         verify_data_shape(bundle_path, net_id, config_file)
         print("data shape is verified correctly.")
-    if mode == "min":
-        return
 
     # The following tests require to use GPU
     if bundle in exclude_verify_torchscript_list:


### PR DESCRIPTION
Fixes #234  .

### Description
This PR modifies the pull requests title of auto created PR that used to update `model_info.json`, then only cpu tests will be used and we can save some time in waiting for assigning gpu resources.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
