### PR TITLE
Update GDrive URLs

### DIFF
--- a/models/brats_mri_segmentation/large_files.yml
+++ b/models/brats_mri_segmentation/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1UFERbDK-Q1hKHqH-shKFcEIE-WPvYMN_/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1UFERbDK-Q1hKHqH-shKFcEIE-WPvYMN_"
     hash_val: "870e677b782a5184cbc48db1456b78e8"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/1s_sfFpCN7vkfNHdzH-ZvMlLpTE38Mx3o/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1s_sfFpCN7vkfNHdzH-ZvMlLpTE38Mx3o"
     hash_val: "c82f693c8f671e9899d21c2f241892f0"
     hash_type: "md5"

--- a/models/breast_density_classification/large_files.yml
+++ b/models/breast_density_classification/large_files.yml
@@ -1,5 +1,5 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1rmIW3Cnv_Ss6raAIfB5WDXywJFmU_BKa/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1rmIW3Cnv_Ss6raAIfB5WDXywJFmU_BKa"
     hash_val: "4a474db59cc1cc85411cb4bdcbc3efd7"
     hash_type: "md5"

--- a/models/endoscopic_inbody_classification/large_files.yml
+++ b/models/endoscopic_inbody_classification/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/14CS-s1uv2q6WedYQGeFbZeEWIkoyNa-x/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=14CS-s1uv2q6WedYQGeFbZeEWIkoyNa-x"
     hash_val: "4f24cc6922a85f1c6c4e9b53a6a3c392"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/1fOoJ4n5DWKHrt9QXTZ2sXwr9C-YvVGCM/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1fOoJ4n5DWKHrt9QXTZ2sXwr9C-YvVGCM"
     hash_val: "c2995ff581c3481e7e24cd7b6964bbd8"
     hash_type: "md5"

--- a/models/endoscopic_tool_segmentation/large_files.yml
+++ b/models/endoscopic_tool_segmentation/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/19yS3t2oLBiB7wT-qeQ82da95VJs_vzRK/view?usp=share_link"
+    url: "https://drive.google.com/uc?id=19yS3t2oLBiB7wT-qeQ82da95VJs_vzRK"
     hash_val: "9d568aaf7188b7b3f254f87c8656d7fe"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/1cDZ3Jr7mhpzdzaFyz8yHNowH8k0T1VZz/view?usp=share_link"
+    url: "https://drive.google.com/uc?id=1cDZ3Jr7mhpzdzaFyz8yHNowH8k0T1VZz"
     hash_val: "e83d1849dd051ac67168093d53824fb1"
     hash_type: "md5"

--- a/models/mednist_reg/large_files.yml
+++ b/models/mednist_reg/large_files.yml
@@ -1,5 +1,5 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1qhoPDrl_ZTDWRX8bvlO72sxS3Oxcod9H/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1qhoPDrl_ZTDWRX8bvlO72sxS3Oxcod9H"
     hash_val: "7970f6df5daaa2dff272afd448ea944e"
     hash_type: "md5"

--- a/models/pathology_nuclei_classification/large_files.yml
+++ b/models/pathology_nuclei_classification/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1EIBpgk-Vq3s-yabX-l7L4c-4rGCTfV2S/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1EIBpgk-Vq3s-yabX-l7L4c-4rGCTfV2S"
     hash_val: "b3fa98d5b0972e730ec3a74e13281461"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/1IGcDGfJMIIoF1KmteV9k53i96pUpcugJ/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1IGcDGfJMIIoF1KmteV9k53i96pUpcugJ"
     hash_val: "26d8f5c5f913eed00447b747d61842f3"
     hash_type: "md5"

--- a/models/pathology_nuclick_annotation/large_files.yml
+++ b/models/pathology_nuclick_annotation/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/13qAvx601WO_89VBpVRgHavgOERE6irlX/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=13qAvx601WO_89VBpVRgHavgOERE6irlX"
     hash_val: "6f91fdf43e98fdc5d380ad77aeff48a6"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/1w6MMhPa_ZqJjWiuf4bB2cDFwOtXtrYzs/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1w6MMhPa_ZqJjWiuf4bB2cDFwOtXtrYzs"
     hash_val: "3e87ef3f72611a665f8cf675126b7f5e"
     hash_type: "md5"

--- a/models/renalStructures_UNEST_segmentation/large_files.yml
+++ b/models/renalStructures_UNEST_segmentation/large_files.yml
@@ -1,5 +1,5 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/19um4b5X8ZrzQY6YTU92LOknLKRx4S5rw/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=19um4b5X8ZrzQY6YTU92LOknLKRx4S5rw"
     hash_val: ""
     hash_type: ""

--- a/models/spleen_ct_segmentation/large_files.yml
+++ b/models/spleen_ct_segmentation/large_files.yml
@@ -1,9 +1,9 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/15QO4F133S1sHYtpF5oRvlaVEughdtvQ-/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=15QO4F133S1sHYtpF5oRvlaVEughdtvQ-"
     hash_val: "b418a2dc8672ce2fd98dc255036e7a3d"
     hash_type: "md5"
   - path: "models/model.ts"
-    url: "https://drive.google.com/file/d/19FB41FP851zvCq1udjn4sIuPdcNpox-v/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=19FB41FP851zvCq1udjn4sIuPdcNpox-v"
     hash_val: "7264b8da9b5b76302efc97f207c6869e"
     hash_type: "md5"

--- a/models/swin_unetr_btcv_segmentation/large_files.yml
+++ b/models/swin_unetr_btcv_segmentation/large_files.yml
@@ -1,5 +1,5 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1x4QUYTdR2MMLv1PxZLYxcRzHabwZioGH/view?usp=share_link"
+    url: "https://drive.google.com/uc?id=1x4QUYTdR2MMLv1PxZLYxcRzHabwZioGH"
     hash_val: ""
     hash_type: ""

--- a/models/wholeBrainSeg_Large_UNEST_segmentation/large_files.yml
+++ b/models/wholeBrainSeg_Large_UNEST_segmentation/large_files.yml
@@ -1,5 +1,5 @@
 large_files:
   - path: "models/model.pt"
-    url: "https://drive.google.com/file/d/1aBbzCodYZ4nk3VtuQ71QZoRGN0ZFxaiR/view?usp=sharing"
+    url: "https://drive.google.com/uc?id=1aBbzCodYZ4nk3VtuQ71QZoRGN0ZFxaiR"
     hash_val: ""
     hash_type: ""


### PR DESCRIPTION
### Description
This PR makes the GDrive URL of the model weights (in `large_files.yml`)to be downloadable using [`gdown`](https://github.com/wkentaro/gdown), which requires using `/uc?id=` instead of `/file/d/`.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
