### PR TITLE
dep monai 1.1.0rc2 -> 1.1.0

### DIFF
--- a/models/mednist_reg/configs/metadata.json
+++ b/models/mednist_reg/configs/metadata.json
@@ -1,11 +1,12 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "changelog": {
+        "0.0.3": "update to use monai 1.1.0",
         "0.0.2": "update to use rc1",
         "0.0.1": "Initial version"
     },
-    "monai_version": "1.1.0rc1",
+    "monai_version": "1.1.0",
     "pytorch_version": "1.13.0",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/pathology_nuclei_classification/configs/metadata.json
+++ b/models/pathology_nuclei_classification/configs/metadata.json
@@ -1,11 +1,12 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "changelog": {
+        "0.0.3": "Update to use MONAI 1.1.0",
         "0.0.2": "Update The Torch Vision Transform",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.1.0rc2",
+    "monai_version": "1.1.0",
     "pytorch_version": "1.13.0",
     "numpy_version": "1.21.2",
     "optional_packages_version": {

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -1,10 +1,11 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "changelog": {
+        "0.1.1": "update to use monai 1.1.0",
         "0.1.0": "complete the model package"
     },
-    "monai_version": "1.1.0rc2",
+    "monai_version": "1.1.0",
     "pytorch_version": "1.13.0",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/pathology_nuclick_annotation/configs/metadata.json
+++ b/models/pathology_nuclick_annotation/configs/metadata.json
@@ -1,11 +1,12 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "changelog": {
+        "0.0.3": "Update to use MONAI 1.1.0",
         "0.0.2": "Update The Torch Vision Transform",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.1.0rc2",
+    "monai_version": "1.1.0",
     "pytorch_version": "1.13.0",
     "numpy_version": "1.21.2",
     "optional_packages_version": {


### PR DESCRIPTION
Signed-off-by: Wenqi Li <wenqil@nvidia.com>

update to use `1.1.0` instead of `1.1.0rc2`

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [x] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [x] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
