### PR TITLE
Fix evaluation for nuclick and nuclei classification bundles

### DIFF
--- a/models/pathology_nuclei_classification/configs/evaluate.json
+++ b/models/pathology_nuclei_classification/configs/evaluate.json
@@ -6,12 +6,27 @@
             {
                 "_target_": "Activationsd",
                 "keys": "pred",
-                "sigmoid": true
+                "softmax": true
             },
             {
                 "_target_": "AsDiscreted",
-                "keys": "pred",
-                "threshold": 0.5
+                "keys": [
+                    "pred",
+                    "label"
+                ],
+                "argmax": [
+                    true,
+                    false
+                ],
+                "to_onehot": 4
+            },
+            {
+                "_target_": "ToTensord",
+                "keys": [
+                    "pred",
+                    "label"
+                ],
+                "device": "@device"
             },
             {
                 "_target_": "SaveImaged",
@@ -39,11 +54,11 @@
             "_target_": "MetricsSaver",
             "save_dir": "@output_dir",
             "metrics": [
-                "val_mean_dice",
-                "val_acc"
+                "val_f1",
+                "val_accuracy"
             ],
             "metric_details": [
-                "val_mean_dice"
+                "val_f1"
             ],
             "batch_transform": "$monai.handlers.from_engine(['image_meta_dict'])",
             "summary_ops": "*"

--- a/models/pathology_nuclei_classification/configs/metadata.json
+++ b/models/pathology_nuclei_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "changelog": {
+        "0.0.4": "Fix evaluation",
         "0.0.3": "Update to use MONAI 1.1.0",
         "0.0.2": "Update The Torch Vision Transform",
         "0.0.1": "initialize the model package structure"

--- a/models/pathology_nuclei_classification/configs/train.json
+++ b/models/pathology_nuclei_classification/configs/train.json
@@ -30,7 +30,7 @@
         "params": "$@network.parameters()",
         "lr": 0.0001
     },
-    "max_epochs": 5,
+    "max_epochs": 50,
     "train": {
         "preprocessing": {
             "_target_": "Compose",
@@ -259,7 +259,8 @@
                     "_target_": "SelectItemsd",
                     "keys": [
                         "image",
-                        "label"
+                        "label",
+                        "image_meta_dict"
                     ]
                 }
             ]

--- a/models/pathology_nuclick_annotation/configs/evaluate.json
+++ b/models/pathology_nuclick_annotation/configs/evaluate.json
@@ -40,7 +40,7 @@
             "save_dir": "@output_dir",
             "metrics": [
                 "val_mean_dice",
-                "val_acc"
+                "val_accuracy"
             ],
             "metric_details": [
                 "val_mean_dice"

--- a/models/pathology_nuclick_annotation/configs/metadata.json
+++ b/models/pathology_nuclick_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "changelog": {
+        "0.0.4": "Fix evaluation",
         "0.0.3": "Update to use MONAI 1.1.0",
         "0.0.2": "Update The Torch Vision Transform",
         "0.0.1": "initialize the model package structure"

--- a/models/pathology_nuclick_annotation/configs/train.json
+++ b/models/pathology_nuclick_annotation/configs/train.json
@@ -243,7 +243,8 @@
                     "_target_": "SelectItemsd",
                     "keys": [
                         "image",
-                        "label"
+                        "label",
+                        "image_meta_dict"
                     ]
                 }
             ]


### PR DESCRIPTION
Signed-off-by: Sachidanand Alle <sachidanand.alle@gmail.com>

Fixes #
Fix evaluation for nuclick and nuclei classification bundles

### Description
Fix evaluation for nuclick and nuclei classification bundles

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
