### PR TITLE
297 fix pytype issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,3 +22,33 @@ exclude = '''
   | monai/_version.py
 )
 '''
+
+[tool.pytype]
+# Space-separated list of files or directories to process.
+inputs = ["models", "ci"]
+# Keep going past errors to analyze as many files as possible.
+keep_going = true
+# Run N jobs in parallel.
+jobs = 8
+# All pytype output goes here.
+output = ".pytype"
+# Paths to source code directories, separated by ':'.
+pythonpath = "."
+# Check attribute values against their annotations.
+check_attribute_types = true
+# Check container mutations against their annotations.
+check_container_types = true
+# Check parameter defaults and assignments against their annotations.
+check_parameter_types = true
+# Check variable values against their annotations.
+check_variable_types = true
+# Comma or space separated list of error names to ignore.
+disable = ["pyi-error"]
+# Report errors.
+report_errors = true
+# Experimental: Infer precise return types even for invalid function calls.
+precise_return = true
+# Experimental: solve unknown types to label with structural types.
+protocols = true
+# Experimental: Only load submodules that are explicitly imported.
+strict_import = false

--- a/runtests.sh
+++ b/runtests.sh
@@ -357,7 +357,8 @@ then
         exit 1
     else
         ${cmdPrefix}${PY_EXE} -m pytype --version
-        ${cmdPrefix}${PY_EXE} -m pytype models -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+
+        ${cmdPrefix}${PY_EXE} -m pytype -j ${NUM_PARALLEL} --python-version="$(${PY_EXE} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")" "$(pwd)"
 
         pytype_status=$?
         if [ ${pytype_status} -ne 0 ]

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,6 +5,7 @@ max_line_length = 120
 # E501 is not flexible enough, we're using B950 instead
 # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
 # B023 https://github.com/Project-MONAI/MONAI/issues/4627
+# B028 https://github.com/Project-MONAI/MONAI/issues/5855
 ignore =
     E203
     E501
@@ -15,6 +16,7 @@ ignore =
     N812
     B023
     B905
+    B028
 per_file_ignores = __init__.py: F401, __main__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 
@@ -24,57 +26,3 @@ profile = black
 line_length = 120
 skip = .git, .eggs, venv, .venv, versioneer.py, _version.py, conf.py
 skip_glob = *.pyi
-
-[mypy]
-# Suppresses error messages about imports that cannot be resolved.
-ignore_missing_imports = True
-# Changes the treatment of arguments with a default value of None by not implicitly making their type Optional.
-no_implicit_optional = True
-# Warns about casting an expression to its inferred type.
-warn_redundant_casts = True
-# No error on unneeded # type: ignore comments.
-warn_unused_ignores = False
-# Shows a warning when returning a value with type Any from a function declared with a non-Any return type.
-warn_return_any = True
-# Prohibit equality checks, identity checks, and container checks between non-overlapping types.
-strict_equality = True
-# Shows column numbers in error messages.
-show_column_numbers = True
-# Shows error codes in error messages.
-show_error_codes = True
-# Use visually nicer output in error messages: use soft word wrap, show source code snippets, and show error location markers.
-pretty = False
-
-[mypy-versioneer]
-# Ignores all non-fatal errors.
-ignore_errors = True
-
-[pytype]
-# Space-separated list of files or directories to exclude.
-exclude = versioneer.py _version.py
-# Keep going past errors to analyze as many files as possible.
-keep_going = True
-# Run N jobs in parallel.
-jobs = 8
-# All pytype output goes here.
-output = .pytype
-# Paths to source code directories, separated by ':'.
-pythonpath = .
-# Check attribute values against their annotations.
-check_attribute_types = True
-# Check container mutations against their annotations.
-check_container_types = True
-# Check parameter defaults and assignments against their annotations.
-check_parameter_types = True
-# Check variable values against their annotations.
-check_variable_types = True
-# Comma or space separated list of error names to ignore.
-disable = pyi-error
-# Report errors.
-report_errors = True
-# Experimental: Infer precise return types even for invalid function calls.
-precise_return = True
-# Experimental: solve unknown types to label with structural types.
-protocols = True
-# Experimental: Only load submodules that are explicitly imported.
-strict_import = False


### PR DESCRIPTION
Fixes #297 .

### Description
This PR fixes the pytype issue, and also ignore an unnecessary flake8 error. In addition, the unused mypy configs is removed.

The changes refer to:
https://github.com/Project-MONAI/MONAI/issues/5840

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
