### PR TITLE
299 modify flake8 setup

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,6 +6,7 @@ max_line_length = 120
 # N812 lowercase 'torch.nn.functional' imported as non lowercase 'F'
 # B023 https://github.com/Project-MONAI/MONAI/issues/4627
 # B028 https://github.com/Project-MONAI/MONAI/issues/5855
+# B907 https://github.com/Project-MONAI/MONAI/issues/5868
 ignore =
     E203
     E501
@@ -17,6 +18,7 @@ ignore =
     B023
     B905
     B028
+    B907
 per_file_ignores = __init__.py: F401, __main__.py: F401
 exclude = *.pyi,.git,.eggs,monai/_version.py,versioneer.py,venv,.venv,_version.py
 


### PR DESCRIPTION
Fixes #299 .

### Description
This PR is used to fix the B907 error produced by updated flake8.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.