### PR TITLE
Update SwinUNETR Bundle Params to Support torch.jit.trace Conversion

### DIFF
--- a/models/swin_unetr_btcv_segmentation/configs/inference.json
+++ b/models/swin_unetr_btcv_segmentation/configs/inference.json
@@ -15,7 +15,7 @@
         "in_channels": 1,
         "out_channels": 14,
         "feature_size": 48,
-        "use_checkpoint": true
+        "use_checkpoint": false
     },
     "network": "$@network_def.to(@device)",
     "preprocessing": {

--- a/models/swin_unetr_btcv_segmentation/configs/metadata.json
+++ b/models/swin_unetr_btcv_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "changelog": {
+        "0.4.1": "update params to supprot torch.jit.trace torchscript conversion",
         "0.4.0": "add name tag",
         "0.3.9": "use ITKreader to avoid mass logs at image loading",
         "0.3.8": "restructure readme to match updated template",

--- a/models/swin_unetr_btcv_segmentation/configs/train.json
+++ b/models/swin_unetr_btcv_segmentation/configs/train.json
@@ -19,7 +19,7 @@
         "in_channels": 1,
         "out_channels": 14,
         "feature_size": 48,
-        "use_checkpoint": true
+        "use_checkpoint": false
     },
     "network": "$@network_def.to(@device)",
     "loss": {


### PR DESCRIPTION
Disable use_checkpoint param to support torchscript conversion by torch.jit.trace. 

Tested with the bundle, functions and performance are the same. 