### PR TITLE
294 Fix typo of spleen multi-gpu training config [skip gpu]

### DIFF
--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.9",
+    "version": "0.4.0",
     "changelog": {
+        "0.4.0": "fix multi-gpu train config typo",
         "0.3.9": "adapt to BundleWorkflow interface",
         "0.3.8": "add name tag",
         "0.3.7": "restructure readme to match updated template",

--- a/models/spleen_ct_segmentation/configs/multi_gpu_train.json
+++ b/models/spleen_ct_segmentation/configs/multi_gpu_train.json
@@ -26,7 +26,7 @@
     "validate#evaluator#val_handlers": "$None if dist.get_rank() > 0 else @validate#handlers",
     "initialize": [
         "$import torch.distributed as dist",
-        "dist.is_initialized() or dist.init_process_group(backend='nccl')",
+        "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
         "$monai.utils.set_determinism(seed=123)",
         "$setattr(torch.backends.cudnn, 'benchmark', True)",


### PR DESCRIPTION
part of #294 .

### Description
This PR is used to fix the typo comes from #331 .

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
