### PR TITLE
344 Add download step for TensorRT CI [skip gpu]

### DIFF
--- a/ci/download_latest_bundle.py
+++ b/ci/download_latest_bundle.py
@@ -17,7 +17,7 @@ from monai.bundle import download
 from utils import get_latest_version
 
 
-def main(bundle_name: str, models_path: str, download_path: str):
+def download_latest_bundle(bundle_name: str, models_path: str, download_path: str):
     model_info_path = os.path.join(models_path, "model_info.json")
     version = get_latest_version(bundle_name=bundle_name, model_info_path=model_info_path)
     download(name=bundle_name, source="github", version=version, bundle_dir=download_path)
@@ -32,4 +32,4 @@ if __name__ == "__main__":
     bundle_name = args.b
     models_path = args.models_path
     download_path = args.p
-    main(bundle_name, models_path, download_path)
+    download_latest_bundle(bundle_name, models_path, download_path)

--- a/ci/verify_tensorrt.py
+++ b/ci/verify_tensorrt.py
@@ -13,6 +13,7 @@ import os
 
 import torch
 from bundle_custom_data import include_verify_tensorrt_list
+from download_latest_bundle import download_latest_bundle
 from monai.bundle import trt_export
 from verify_bundle import _find_bundle_file
 
@@ -44,14 +45,15 @@ def verify_tensorrt(bundle_path: str, net_id: str, config_file: str, precision: 
         raise
 
 
-def verify_all_tensorrt_bundles(models_path="models"):
+def verify_all_tensorrt_bundles(download_path="download"):
     """
     This function is used to verify all bundles that support TensorRT.
 
     """
     for bundle in include_verify_tensorrt_list:
         print(f"start verifying bundle {bundle}.")
-        bundle_path = os.path.join(models_path, bundle)
+        download_latest_bundle(bundle_name=bundle, models_path="models", download_path=download_path)
+        bundle_path = os.path.join(download_path, bundle)
         net_id, inference_file_name = "network_def", _find_bundle_file(
             os.path.join(bundle_path, "configs"), "inference"
         )


### PR DESCRIPTION
Fixes #344 .

### Description
This PR adds the download step for the TensorRT CI.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
