### PR TITLE
362 Update deterministic settings on several bundles

### DIFF
--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.0",
+    "version": "0.4.1",
     "changelog": {
+        "0.4.1": "add non-deterministic note",
         "0.4.0": "adapt to BundleWorkflow interface",
         "0.3.9": "black autofix format and add name tag",
         "0.3.8": "modify dataset key name",
@@ -18,7 +19,7 @@
         "0.1.1": "update for MetaTensor",
         "0.1.0": "complete the model package"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -56,7 +56,7 @@ Dice score was used for evaluating the performance of the model. This model achi
 - Average: 0.8518
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
 
 #### Training Loss and Dice
 ![A graph showing the training loss and the mean dice over 300 epochs](https://developer.download.nvidia.com/assets/Clara/Images/monai_brats_mri_segmentation_train.png)

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -55,6 +55,8 @@ Dice score was used for evaluating the performance of the model. This model achi
 - Enhancing tumor (ET): 0.7905
 - Average: 0.8518
 
+This bundle is non-deterministic because of the trilinear interpolation used in the network. For more details please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms
+
 #### Training Loss and Dice
 ![A graph showing the training loss and the mean dice over 300 epochs](https://developer.download.nvidia.com/assets/Clara/Images/monai_brats_mri_segmentation_train.png)
 

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -56,13 +56,12 @@ Dice score was used for evaluating the performance of the model. This model achi
 - Average: 0.8518
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss and Dice
 ![A graph showing the training loss and the mean dice over 300 epochs](https://developer.download.nvidia.com/assets/Clara/Images/monai_brats_mri_segmentation_train.png)
 
 #### Validation Dice
-
 ![A graph showing the validation mean dice over 300 epochs](https://developer.download.nvidia.com/assets/Clara/Images/monai_brats_mri_segmentation_val.png)
 
 ## MONAI Bundle Commands
@@ -71,11 +70,13 @@ In addition to the Pythonic APIs, a few command line interfaces (CLI) are provid
 For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
 
 #### Execute training:
+
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
 #### Override the `train` config to execute multi-GPU training:
+
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=8 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
 ```
@@ -83,11 +84,13 @@ torchrun --standalone --nnodes=1 --nproc_per_node=8 -m monai.bundle run --config
 Please note that the distributed training-related options depend on the actual running environment; thus, users may need to remove `--standalone`, modify `--nnodes`, or do some other necessary changes according to the machine used. For more details, please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
 
 #### Override the `train` config to execute evaluation with the trained model:
+
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
 #### Execute inference:
+
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -55,7 +55,8 @@ Dice score was used for evaluating the performance of the model. This model achi
 - Enhancing tumor (ET): 0.7905
 - Average: 0.8518
 
-This bundle is non-deterministic because of the trilinear interpolation used in the network. For more details please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms
+Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 #### Training Loss and Dice
 ![A graph showing the training loss and the mean dice over 300 epochs](https://developer.download.nvidia.com/assets/Clara/Images/monai_brats_mri_segmentation_train.png)

--- a/models/brats_mri_segmentation/docs/README.md
+++ b/models/brats_mri_segmentation/docs/README.md
@@ -55,7 +55,7 @@ Dice score was used for evaluating the performance of the model. This model achi
 - Enhancing tumor (ET): 0.7905
 - Average: 0.8518
 
-Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please note that this bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss and Dice

--- a/models/endoscopic_inbody_classification/configs/metadata.json
+++ b/models/endoscopic_inbody_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "changelog": {
+        "0.3.8": "enable deterministic training",
         "0.3.7": "adapt to BundleWorkflow interface",
         "0.3.6": "add name tag",
         "0.3.5": "fix a comment issue in the data_process script",
@@ -16,7 +17,7 @@
         "0.1.0": "complete the first version model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/endoscopic_inbody_classification/configs/multi_gpu_train.json
+++ b/models/endoscopic_inbody_classification/configs/multi_gpu_train.json
@@ -28,8 +28,7 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/endoscopic_inbody_classification/configs/train.json
+++ b/models/endoscopic_inbody_classification/configs/train.json
@@ -252,8 +252,7 @@
         }
     },
     "initialize": [
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/endoscopic_inbody_classification/docs/README.md
+++ b/models/endoscopic_inbody_classification/docs/README.md
@@ -8,7 +8,7 @@ The [PyTorch model](https://drive.google.com/file/d/14CS-s1uv2q6WedYQGeFbZeEWIko
 ## Data
 The datasets used in this work were provided by [Activ Surgical](https://www.activsurgical.com/).
 
-We've provided a [link](https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/inbody_outbody_samples.zip) of 20 samples (10 in-body and 10 out-body) to show what this dataset looks like.
+Since datasets are private, we provide a [link](https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/inbody_outbody_samples.zip) of 20 samples (10 in-body and 10 out-body) to show what they look like.
 
 ### Preprocessing
 After downloading this dataset, python script in `scripts` folder named `data_process` can be used to generate label json files by running the command below and modifying `datapath` to path of unziped downloaded data. Generated label json files will be stored in `label` folder under the bundle path.

--- a/models/endoscopic_inbody_classification/docs/README.md
+++ b/models/endoscopic_inbody_classification/docs/README.md
@@ -105,11 +105,7 @@ The classification result of every images in `test.json` will be printed to the 
 #### Export checkpoint to TorchScript file:
 
 ```
-python -m monai.bundle ckpt_export network_def \
-    --filepath models/model.ts \
-    --ckpt_file models/model.pt \
-    --meta_file configs/metadata.json \
-    --config_file configs/inference.json
+python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
 # References

--- a/models/endoscopic_tool_segmentation/configs/metadata.json
+++ b/models/endoscopic_tool_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "changelog": {
+        "0.4.6": "enable deterministic training",
         "0.4.5": "add the command of executing inference with TensorRT models",
         "0.4.4": "adapt to BundleWorkflow interface",
         "0.4.3": "update this bundle to support TensorRT convert",
@@ -16,7 +17,7 @@
         "0.1.0": "complete the first version model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/endoscopic_tool_segmentation/configs/multi_gpu_evaluate.json
+++ b/models/endoscopic_tool_segmentation/configs/multi_gpu_evaluate.json
@@ -19,7 +19,6 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"
     ],

--- a/models/endoscopic_tool_segmentation/configs/multi_gpu_train.json
+++ b/models/endoscopic_tool_segmentation/configs/multi_gpu_train.json
@@ -30,7 +30,6 @@
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
         "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@train#trainer.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"

--- a/models/endoscopic_tool_segmentation/configs/train.json
+++ b/models/endoscopic_tool_segmentation/configs/train.json
@@ -275,8 +275,7 @@
         }
     },
     "initialize": [
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/endoscopic_tool_segmentation/docs/README.md
+++ b/models/endoscopic_tool_segmentation/docs/README.md
@@ -100,7 +100,7 @@ python -m monai.bundle run --config_file configs/inference.json
 python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-#### Export checkpoint to TensorRT based models with fp32 or fp16 precision:
+#### Export checkpoint to TensorRT based models with fp32 or fp16 precision
 
 ```
 python -m monai.bundle trt_export --net_id network_def --filepath models/model_trt.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json --precision <fp32/fp16>

--- a/models/endoscopic_tool_segmentation/docs/README.md
+++ b/models/endoscopic_tool_segmentation/docs/README.md
@@ -11,7 +11,6 @@ Datasets used in this work were provided by [Activ Surgical](https://www.activsu
 Since datasets are private, existing public datasets like [EndoVis 2017](https://endovissub2017-roboticinstrumentsegmentation.grand-challenge.org/Data/) can be used to train a similar model.
 
 ### Preprocessing
-
 When using EndoVis or any other dataset, it should be divided into "train", "valid" and "test" folders. Samples in each folder would better be images and converted to jpg format. Otherwise, "images", "labels", "val_images" and "val_labels" parameters in "configs/train.json" and "datalist" in "configs/inference.json" should be modified to fit given dataset. After that, "dataset_dir" parameter in "configs/train.json" and "configs/inference.json" should be changed to root folder which contains previous "train", "valid" and "test" folders.
 
 Please notice that loading data operation in this bundle is adaptive. If images and labels are not in the same format, it may lead to a mismatching problem. For example, if images are in jpg format and labels are in npy format, PIL and Numpy readers will be used separately to load images and labels. Since these two readers have their own way to parse file's shape, loaded labels will be transpose of the correct ones and incur a missmatching problem.

--- a/models/endoscopic_tool_segmentation/docs/README.md
+++ b/models/endoscopic_tool_segmentation/docs/README.md
@@ -100,13 +100,13 @@ python -m monai.bundle run --config_file configs/inference.json
 python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json
 ```
 
-#### Export checkpoint to TensorRT based models with fp32 or fp16 precision
+#### Export checkpoint to TensorRT based models with fp32 or fp16 precision:
 
 ```
 python -m monai.bundle trt_export --net_id network_def --filepath models/model_trt.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json --precision <fp32/fp16>
 ```
 
-#### Execute inference with the TensorRT model
+#### Execute inference with the TensorRT model:
 
 ```
 python -m monai.bundle run --config_file "['configs/inference.json', 'configs/inference_trt.json']"

--- a/models/lung_nodule_ct_detection/configs/metadata.json
+++ b/models/lung_nodule_ct_detection/configs/metadata.json
@@ -1,6 +1,6 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.5",
+    "version": "0.5.4",
     "changelog": {
         "0.5.4": "add non-deterministic note",
         "0.5.3": "adapt to BundleWorkflow interface",

--- a/models/lung_nodule_ct_detection/configs/metadata.json
+++ b/models/lung_nodule_ct_detection/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.3",
+    "version": "0.5.5",
     "changelog": {
+        "0.5.4": "add non-deterministic note",
         "0.5.3": "adapt to BundleWorkflow interface",
         "0.5.2": "black autofix format and add name tag",
         "0.5.1": "modify dataset key name",
@@ -17,7 +18,7 @@
         "0.1.1": "add reference for LIDC dataset",
         "0.1.0": "complete the model package"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/lung_nodule_ct_detection/docs/README.md
+++ b/models/lung_nodule_ct_detection/docs/README.md
@@ -52,7 +52,7 @@ In Evaluation Mode: A list of dictionaries of predicted box, classification labe
 ## Performance
 Coco metric is used for evaluating the performance of the model. The pre-trained model was trained and validated on data fold 0. This model achieves a mAP=0.853, mAR=0.994, AP(IoU=0.1)=0.862, AR(IoU=0.1)=1.0.
 
-Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please note that this bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss

--- a/models/lung_nodule_ct_detection/docs/README.md
+++ b/models/lung_nodule_ct_detection/docs/README.md
@@ -53,7 +53,7 @@ In Evaluation Mode: A list of dictionaries of predicted box, classification labe
 Coco metric is used for evaluating the performance of the model. The pre-trained model was trained and validated on data fold 0. This model achieves a mAP=0.853, mAR=0.994, AP(IoU=0.1)=0.862, AR(IoU=0.1)=1.0.
 
 Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
 
 #### Training Loss
 ![A graph showing the detection train loss](https://developer.download.nvidia.com/assets/Clara/Images/monai_retinanet_detection_train_loss.png)

--- a/models/lung_nodule_ct_detection/docs/README.md
+++ b/models/lung_nodule_ct_detection/docs/README.md
@@ -52,6 +52,9 @@ In Evaluation Mode: A list of dictionaries of predicted box, classification labe
 ## Performance
 Coco metric is used for evaluating the performance of the model. The pre-trained model was trained and validated on data fold 0. This model achieves a mAP=0.853, mAR=0.994, AP(IoU=0.1)=0.862, AR(IoU=0.1)=1.0.
 
+Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+
 #### Training Loss
 ![A graph showing the detection train loss](https://developer.download.nvidia.com/assets/Clara/Images/monai_retinanet_detection_train_loss.png)
 

--- a/models/lung_nodule_ct_detection/docs/README.md
+++ b/models/lung_nodule_ct_detection/docs/README.md
@@ -52,7 +52,7 @@ In Evaluation Mode: A list of dictionaries of predicted box, classification labe
 ## Performance
 Coco metric is used for evaluating the performance of the model. The pre-trained model was trained and validated on data fold 0. This model achieves a mAP=0.853, mAR=0.994, AP(IoU=0.1)=0.862, AR(IoU=0.1)=1.0.
 
-Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 #### Training Loss

--- a/models/lung_nodule_ct_detection/docs/README.md
+++ b/models/lung_nodule_ct_detection/docs/README.md
@@ -53,7 +53,7 @@ In Evaluation Mode: A list of dictionaries of predicted box, classification labe
 Coco metric is used for evaluating the performance of the model. The pre-trained model was trained and validated on data fold 0. This model achieves a mAP=0.853, mAR=0.994, AP(IoU=0.1)=0.862, AR(IoU=0.1)=1.0.
 
 Please note that This bundle is non-deterministic because of the max pooling layer used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss
 ![A graph showing the detection train loss](https://developer.download.nvidia.com/assets/Clara/Images/monai_retinanet_detection_train_loss.png)
@@ -69,16 +69,19 @@ In addition to the Pythonic APIs, a few command line interfaces (CLI) are provid
 For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
 
 #### Execute training:
+
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
 #### Override the `train` config to execute evaluation with the trained model:
+
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
 #### Execute inference on resampled LUNA16 images by setting `"whether_raw_luna16": false` in `inference.json`:
+
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```

--- a/models/pancreas_ct_dints_segmentation/configs/metadata.json
+++ b/models/pancreas_ct_dints_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.7",
+    "version": "0.3.8",
     "changelog": {
+        "0.3.8": "add non-deterministic note",
         "0.3.7": "re-train model with updated dints implementation",
         "0.3.6": "black autofix format and add name tag",
         "0.3.5": "restructure readme to match updated template",

--- a/models/pancreas_ct_dints_segmentation/docs/README.md
+++ b/models/pancreas_ct_dints_segmentation/docs/README.md
@@ -56,7 +56,7 @@ Three channels
 ## Performance
 Dice score is used for evaluating the performance of the model. This model achieves a mean dice score of 0.62.
 
-Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please note that this bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss

--- a/models/pancreas_ct_dints_segmentation/docs/README.md
+++ b/models/pancreas_ct_dints_segmentation/docs/README.md
@@ -57,7 +57,7 @@ Three channels
 Dice score is used for evaluating the performance of the model. This model achieves a mean dice score of 0.62.
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss
 The loss over 3200 epochs (the bright curve is smoothed, and the dark one is the actual curve)

--- a/models/pancreas_ct_dints_segmentation/docs/README.md
+++ b/models/pancreas_ct_dints_segmentation/docs/README.md
@@ -56,7 +56,7 @@ Three channels
 ## Performance
 Dice score is used for evaluating the performance of the model. This model achieves a mean dice score of 0.62.
 
-Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 #### Training Loss

--- a/models/pancreas_ct_dints_segmentation/docs/README.md
+++ b/models/pancreas_ct_dints_segmentation/docs/README.md
@@ -57,7 +57,7 @@ Three channels
 Dice score is used for evaluating the performance of the model. This model achieves a mean dice score of 0.62.
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
 
 #### Training Loss
 The loss over 3200 epochs (the bright curve is smoothed, and the dark one is the actual curve)
@@ -115,7 +115,7 @@ python -m monai.bundle run --config_file "['configs/train.yaml','configs/evaluat
 python -m monai.bundle run --config_file configs/inference.yaml
 ```
 
-#### Export checkpoint for TorchScript
+#### Export checkpoint for TorchScript:
 
 ```
 python -m monai.bundle ckpt_export network_def --filepath models/model.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.yaml

--- a/models/pancreas_ct_dints_segmentation/docs/README.md
+++ b/models/pancreas_ct_dints_segmentation/docs/README.md
@@ -56,6 +56,9 @@ Three channels
 ## Performance
 Dice score is used for evaluating the performance of the model. This model achieves a mean dice score of 0.62.
 
+Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+
 #### Training Loss
 The loss over 3200 epochs (the bright curve is smoothed, and the dark one is the actual curve)
 

--- a/models/pathology_nuclei_classification/configs/metadata.json
+++ b/models/pathology_nuclei_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "changelog": {
+        "0.0.8": "enable deterministic training",
         "0.0.7": "update benchmark on A100",
         "0.0.6": "adapt to BundleWorkflow interface",
         "0.0.5": "add name tag",

--- a/models/pathology_nuclei_classification/configs/multi_gpu_evaluate.json
+++ b/models/pathology_nuclei_classification/configs/multi_gpu_evaluate.json
@@ -21,7 +21,6 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$import scripts",

--- a/models/pathology_nuclei_classification/configs/multi_gpu_train.json
+++ b/models/pathology_nuclei_classification/configs/multi_gpu_train.json
@@ -31,7 +31,6 @@
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
         "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@train#trainer.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"

--- a/models/pathology_nuclei_classification/configs/train.json
+++ b/models/pathology_nuclei_classification/configs/train.json
@@ -343,8 +343,7 @@
     "initialize": [
         "$import sys",
         "$sys.path.append(@bundle_root)",
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/pathology_nuclei_classification/docs/README.md
+++ b/models/pathology_nuclei_classification/docs/README.md
@@ -98,7 +98,7 @@ Example `dataset.json` in output folder:
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_in_out.jpeg)
 
-## Scores
+## Performance
 This model achieves the following F1 score on the validation data provided as part of the dataset:
 
 - Train F1 score = 0.941
@@ -125,26 +125,29 @@ Confusion Metrics for <b>Training</b> for individual classes are (at epoch 50):
 
 
 
-## Training Performance
+#### Training Performance
 A graph showing the training Loss and F1-score over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_loss_v2.png) <br>
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_f1_v2.png) <br>
 
-## Validation Performance
+#### Validation Performance
 A graph showing the validation F1-score over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_f1_v2.png) <br>
 
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
-## commands example
-Execute training:
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training:
 
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
-Override the `train` config to execute multi-GPU training:
+#### Override the `train` config to execute multi-GPU training:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
@@ -153,19 +156,19 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 Please note that the distributed training related options depend on the actual running environment, thus you may need to remove `--standalone`, modify `--nnodes` or do some other necessary changes according to the machine you used.
 Please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) for more details.
 
-Override the `train` config to execute evaluation with the trained model:
+#### Override the `train` config to execute evaluation with the trained model:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
+#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json','configs/multi_gpu_evaluate.json']"
 ```
 
-Execute inference:
+#### Execute inference:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "changelog": {
+        "0.1.6": "add non-deterministic note",
         "0.1.5": "update benchmark on A100",
         "0.1.4": "adapt to BundleWorkflow interface",
         "0.1.3": "add name tag",

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -65,7 +65,8 @@ Fast mode:
 
 Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
 
-This bundle is non-deterministic, for more details please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms
+Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 #### Training Loss and Dice
 

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -58,7 +58,7 @@ Fast mode:
 
 Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
 
-Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please note that this bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss and Dice

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -5,7 +5,7 @@ A pre-trained model for simultaneous segmentation and classification of nuclei w
 The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
 ### Pre-trained weights
-- The first stage is trained with pre-trained weights from some internal data.The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
+The first stage is trained with pre-trained weights from some internal data.The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
 `PRETRAIN_MODEL_URL` is "https://drive.google.com/u/1/uc?id=1KntZge40tAHgyXmHYVqZZ5d2p_4Qr2l5&export=download" which can be used in bash code below.

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -65,7 +65,7 @@ Fast mode:
 
 Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
 
-Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 #### Training Loss and Dice

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -2,7 +2,7 @@
 A pre-trained model for simultaneous segmentation and classification of nuclei within multi-tissue histology images based on CoNSeP data. The details of the model can be found in [1].
 
 ## Workflow
-The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
+The model is trained to simultaneously segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
 ### Pre-trained weights
 The first stage is trained with pre-trained weights from some internal data.The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -2,11 +2,11 @@
 A pre-trained model for simultaneous segmentation and classification of nuclei within multi-tissue histology images based on CoNSeP data. The details of the model can be found in [1].
 
 ## Workflow
-The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, it uses [270, 270] and [80, 80] for `patch_size` and `out_size` respectively. If "fast" mode is specified, it uses [256, 256] and [164, 164] for `patch_size` and `out_size` respectively. The results we show below are based on the "fast" model.
+The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
-- We train the first stage with pre-trained weights from some internal data.
-
-- The original author's repo also has pre-trained weights which is for non-commercial use. Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use. The license for the pre-trained model is different than MONAI license. Please check the source where these weights are obtained from: <https://github.com/vqdang/hover_net#data-format>
+### Pre-trained weights
+- The first stage is trained with pre-trained weights from some internal data.The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
+Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
 `PRETRAIN_MODEL_URL` is "https://drive.google.com/u/1/uc?id=1KntZge40tAHgyXmHYVqZZ5d2p_4Qr2l5&export=download" which can be used in bash code below.
 

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -66,7 +66,7 @@ Fast mode:
 Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
 
 Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
 
 #### Training Loss and Dice
 
@@ -86,9 +86,12 @@ stage2:
 
 ![A graph showing the validation mean dice over 50 epochs in stage2](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_segmentation_classification_val_stage1_v2.png)
 
-## commands example
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
-Execute training, the evaluation in the training were evaluated on patches:
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training, the evaluation in the training were evaluated on patches:
 
 - Run first stage
 
@@ -102,7 +105,7 @@ python -m monai.bundle run --config_file configs/train.json --network_def#pretra
 python -m monai.bundle run --config_file configs/train.json --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
 
-Override the `train` config to execute multi-GPU training:
+#### Override the `train` config to execute multi-GPU training:
 
 - Run first stage
 
@@ -116,13 +119,13 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 4 --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
 
-Override the `train` config to execute evaluation with the trained model, here we evaluated dice from the whole input instead of the patches:
+#### Override the `train` config to execute evaluation with the trained model, here we evaluated dice from the whole input instead of the patches:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-### Execute inference
+#### Execute inference:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -1,9 +1,7 @@
 # Model Overview
-
 A pre-trained model for simultaneous segmentation and classification of nuclei within multi-tissue histology images based on CoNSeP data. The details of the model can be found in [1].
 
 ## Workflow
-
 The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, it uses [270, 270] and [80, 80] for `patch_size` and `out_size` respectively. If "fast" mode is specified, it uses [256, 256] and [164, 164] for `patch_size` and `out_size` respectively. The results we show below are based on the "fast" model.
 
 - We train the first stage with pre-trained weights from some internal data.
@@ -15,7 +13,6 @@ The model is trained to simultaneous segment and classify nuclei. Training is do
 ![Model workflow](https://developer.download.nvidia.com/assets/Clara/Images/monai_hovernet_pipeline.png)
 
 ## Data
-
 The training data is from <https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/>.
 
 - Target: segment instance-level nuclei and classify the nuclei type
@@ -32,7 +29,6 @@ python scripts/prepare_patches.py -root your-concep-dataset-path
 ```
 
 ## Training configuration
-
 This model utilized a two-stage approach. The training was performed with the following:
 
 - GPU: At least 24GB of GPU memory.
@@ -43,19 +39,16 @@ This model utilized a two-stage approach. The training was performed with the fo
 - Loss: HoVerNetLoss
 
 ## Input
-
 Input: RGB images
 
 ## Output
-
 Output: a dictionary with the following keys:
 
 1. nucleus_prediction: predict whether or not a pixel belongs to the nuclei or background
 2. horizontal_vertical: predict the horizontal and vertical distances of nuclear pixels to their centres of mass
 3. type_prediction: predict the type of nucleus for each pixel
 
-## Model Performance
-
+## Performance
 The achieved metrics on the validation data are:
 
 Fast mode:
@@ -66,10 +59,9 @@ Fast mode:
 Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
 
 Please note that This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss and Dice
-
 stage1:
 ![A graph showing the training loss and the mean dice over 50 epochs in stage1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_segmentation_classification_train_stage0_v2.png)
 
@@ -77,7 +69,6 @@ stage2:
 ![A graph showing the training loss and the mean dice over 50 epochs in stage2](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_segmentation_classification_train_stage1_v2.png)
 
 #### Validation Dice
-
 stage1:
 
 ![A graph showing the validation mean dice over 50 epochs in stage1](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_segmentation_classification_val_stage0_v2.png)
@@ -94,13 +85,11 @@ For more details usage instructions, visit the [MONAI Bundle Configuration Page]
 #### Execute training, the evaluation in the training were evaluated on patches:
 
 - Run first stage
-
 ```
 python -m monai.bundle run --config_file configs/train.json --network_def#pretrained_url `PRETRAIN_MODEL_URL` --stage 0
 ```
 
 - Run second stage
-
 ```
 python -m monai.bundle run --config_file configs/train.json --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
@@ -108,13 +97,11 @@ python -m monai.bundle run --config_file configs/train.json --network_def#freeze
 #### Override the `train` config to execute multi-GPU training:
 
 - Run first stage
-
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 8 --network_def#freeze_encoder True --network_def#pretrained_url `PRETRAIN_MODEL_URL --stage 0
 ```
 
 - Run second stage
-
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 4 --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
@@ -132,11 +119,9 @@ python -m monai.bundle run --config_file configs/inference.json
 ```
 
 # Disclaimer
-
 This is an example, not to be used for diagnostic purposes.
 
 # References
-
 [1] Simon Graham, Quoc Dang Vu, Shan E Ahmed Raza, Ayesha Azam, Yee Wah Tsang, Jin Tae Kwak, Nasir Rajpoot, Hover-Net: Simultaneous segmentation and classification of nuclei in multi-tissue histology images, Medical Image Analysis, 2019 https://doi.org/10.1016/j.media.2019.101563
 
 # License

--- a/models/pathology_nuclick_annotation/configs/metadata.json
+++ b/models/pathology_nuclick_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "changelog": {
+        "0.0.8": "enable deterministic training",
         "0.0.7": "Update with figure links",
         "0.0.6": "adapt to BundleWorkflow interface",
         "0.0.5": "add name tag",
@@ -10,7 +11,7 @@
         "0.0.2": "Update The Torch Vision Transform",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/pathology_nuclick_annotation/configs/multi_gpu_evaluate.json
+++ b/models/pathology_nuclick_annotation/configs/multi_gpu_evaluate.json
@@ -21,7 +21,6 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"
     ],

--- a/models/pathology_nuclick_annotation/configs/multi_gpu_train.json
+++ b/models/pathology_nuclick_annotation/configs/multi_gpu_train.json
@@ -31,7 +31,6 @@
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
         "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@train#trainer.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"

--- a/models/pathology_nuclick_annotation/configs/train.json
+++ b/models/pathology_nuclick_annotation/configs/train.json
@@ -321,8 +321,7 @@
     "initialize": [
         "$import sys",
         "$sys.path.append(@bundle_root)",
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/pathology_nuclick_annotation/docs/README.md
+++ b/models/pathology_nuclick_annotation/docs/README.md
@@ -116,14 +116,18 @@ A graph showing the validation mean Dice over 50 epochs.
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_val_dice.jpeg) <br>
 
 
-## commands example
-Execute training:
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
+
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training:
 
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
-Override the `train` config to execute multi-GPU training:
+#### Override the `train` config to execute multi-GPU training:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
@@ -132,19 +136,19 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 Please note that the distributed training related options depend on the actual running environment, thus you may need to remove `--standalone`, modify `--nnodes` or do some other necessary changes according to the machine you used.
 Please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) for more details.
 
-Override the `train` config to execute evaluation with the trained model:
+#### Override the `train` config to execute evaluation with the trained model:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
+#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json','configs/multi_gpu_evaluate.json']"
 ```
 
-Execute inference:
+#### Execute inference:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "changelog": {
+        "0.4.5": "enable deterministic training",
         "0.4.4": "add the command of executing inference with TensorRT models",
         "0.4.3": "fix figure and weights inconsistent error",
         "0.4.2": "use torch 1.13.1",
@@ -22,7 +23,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_ct_segmentation/configs/multi_gpu_evaluate.json
+++ b/models/spleen_ct_segmentation/configs/multi_gpu_evaluate.json
@@ -19,7 +19,6 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"
     ],

--- a/models/spleen_ct_segmentation/configs/multi_gpu_train.json
+++ b/models/spleen_ct_segmentation/configs/multi_gpu_train.json
@@ -29,7 +29,6 @@
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
         "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
         "$import logging",
         "$@train#trainer.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)"

--- a/models/spleen_ct_segmentation/configs/train.json
+++ b/models/spleen_ct_segmentation/configs/train.json
@@ -299,8 +299,7 @@
         }
     },
     "initialize": [
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/spleen_ct_segmentation/docs/README.md
+++ b/models/spleen_ct_segmentation/docs/README.md
@@ -99,7 +99,7 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 python -m monai.bundle run --config_file configs/inference.json
 ```
 
-#### Export checkpoint to TensorRT based models with fp32 or fp16 precision:
+#### Export checkpoint to TensorRT based models with fp32 or fp16 precision
 
 ```
 python -m monai.bundle trt_export --net_id network_def --filepath models/model_trt.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json --precision <fp32/fp16> --dynamic_batchsize "[1, 4, 8]"

--- a/models/spleen_ct_segmentation/docs/README.md
+++ b/models/spleen_ct_segmentation/docs/README.md
@@ -99,13 +99,13 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 python -m monai.bundle run --config_file configs/inference.json
 ```
 
-#### Export checkpoint to TensorRT based models with fp32 or fp16 precision
+#### Export checkpoint to TensorRT based models with fp32 or fp16 precision:
 
 ```
 python -m monai.bundle trt_export --net_id network_def --filepath models/model_trt.ts --ckpt_file models/model.pt --meta_file configs/metadata.json --config_file configs/inference.json --precision <fp32/fp16> --dynamic_batchsize "[1, 4, 8]"
 ```
 
-#### Execute inference with the TensorRT model
+#### Execute inference with the TensorRT model:
 
 ```
 python -m monai.bundle run --config_file "['configs/inference.json', 'configs/inference_trt.json']"

--- a/models/spleen_deepedit_annotation/configs/evaluate.json
+++ b/models/spleen_deepedit_annotation/configs/evaluate.json
@@ -9,6 +9,21 @@
                 "softmax": true
             },
             {
+                "_target_": "Invertd",
+                "keys": [
+                    "pred",
+                    "label"
+                ],
+                "transform": "@validate#preprocessing",
+                "orig_keys": "image",
+                "meta_key_postfix": "meta_dict",
+                "nearest_interp": [
+                    false,
+                    true
+                ],
+                "to_tensor": true
+            },
+            {
                 "_target_": "AsDiscreted",
                 "keys": [
                     "pred",

--- a/models/spleen_deepedit_annotation/configs/evaluate.json
+++ b/models/spleen_deepedit_annotation/configs/evaluate.json
@@ -9,21 +9,6 @@
                 "softmax": true
             },
             {
-                "_target_": "Invertd",
-                "keys": [
-                    "pred",
-                    "label"
-                ],
-                "transform": "@validate#preprocessing",
-                "orig_keys": "image",
-                "meta_key_postfix": "meta_dict",
-                "nearest_interp": [
-                    false,
-                    true
-                ],
-                "to_tensor": true
-            },
-            {
                 "_target_": "AsDiscreted",
                 "keys": [
                     "pred",

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -2,7 +2,7 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
     "version": "0.3.9",
     "changelog": {
-        "0.3.9": "enable determinism and add invert on evaluate config",
+        "0.3.9": "enable deterministic training",
         "0.3.8": "adapt to BundleWorkflow interface",
         "0.3.7": "add name tag",
         "0.3.6": "restructure readme to match updated template",

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.8",
+    "version": "0.3.9",
     "changelog": {
+        "0.3.9": "enable determinism and add invert on evaluate config",
         "0.3.8": "adapt to BundleWorkflow interface",
         "0.3.7": "add name tag",
         "0.3.6": "restructure readme to match updated template",
@@ -15,7 +16,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_deepedit_annotation/configs/multi_gpu_train.json
+++ b/models/spleen_deepedit_annotation/configs/multi_gpu_train.json
@@ -28,8 +28,7 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/spleen_deepedit_annotation/configs/train.json
+++ b/models/spleen_deepedit_annotation/configs/train.json
@@ -426,8 +426,7 @@
         }
     },
     "initialize": [
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/swin_unetr_btcv_segmentation/configs/metadata.json
+++ b/models/swin_unetr_btcv_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "changelog": {
+        "0.4.5": "enable deterministic training",
         "0.4.4": "update numbers",
         "0.4.3": "adapt to BundleWorkflow interface",
         "0.4.2": "fix train params of use_checkpoint",
@@ -21,7 +22,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/swin_unetr_btcv_segmentation/configs/multi_gpu_train.json
+++ b/models/swin_unetr_btcv_segmentation/configs/multi_gpu_train.json
@@ -28,8 +28,7 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/swin_unetr_btcv_segmentation/configs/train.json
+++ b/models/swin_unetr_btcv_segmentation/configs/train.json
@@ -319,8 +319,7 @@
         }
     },
     "initialize": [
-        "$monai.utils.set_determinism(seed=123)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)"
+        "$monai.utils.set_determinism(seed=123)"
     ],
     "run": [
         "$@train#trainer.run()"

--- a/models/wholeBody_ct_segmentation/configs/metadata.json
+++ b/models/wholeBody_ct_segmentation/configs/metadata.json
@@ -1,13 +1,14 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "changelog": {
+        "0.1.3": "add non-deterministic note",
         "0.1.2": "Update figure with links",
         "0.1.1": "adapt to BundleWorkflow interface and val metric",
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc3",
+    "monai_version": "1.2.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -102,7 +102,7 @@ CPU: Memory: **2.3G**
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 
-Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Please note that this bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 ## MONAI Bundle Commands

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -103,7 +103,7 @@ CPU: Memory: **2.3G**
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 ## MONAI Bundle Commands
 In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -102,7 +102,7 @@ CPU: Memory: **2.3G**
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 
-Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
 
 ## MONAI Bundle Commands

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -102,6 +102,9 @@ CPU: Memory: **2.3G**
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 
+Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproduce the training process may not get exactly the same performance.
+Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+
 ## MONAI Bundle Commands
 In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -103,20 +103,20 @@ CPU: Memory: **2.3G**
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 
 Please note that This bundle is non-deterministic because of the trilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
-Please refer to https://pytorch.org/docs/stable/generated/torch.use_deterministic_algorithms.html#torch.use_deterministic_algorithms for more details about the reproducibility.
+Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about the reproducibility.
 
 ## MONAI Bundle Commands
 In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
 For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
 
-#### Execute training
+#### Execute training:
 
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
-#### Override the `train` config to execute multi-GPU training
+#### Override the `train` config to execute multi-GPU training:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
@@ -124,24 +124,24 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 
 Please note that the distributed training-related options depend on the actual running environment; thus, users may need to remove `--standalone`, modify `--nnodes`, or do some other necessary changes according to the machine used. For more details, please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
 
-#### Override the `train` config to execute evaluation with the trained model
+#### Override the `train` config to execute evaluation with the trained model:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation
+#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json','configs/multi_gpu_evaluate.json']"
 ```
 
-#### Execute inference
+#### Execute inference:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```
-#### Execute inference with Data Samples
+#### Execute inference with Data Samples:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json --datalist "['sampledata/imagesTr/s0037.nii.gz','sampledata/imagesTr/s0038.nii.gz']"


### PR DESCRIPTION
Fixes #362 .

### Description
This PR adds deterministic settings on several bundles mentioned in #362 , and for unsupported bundles, I added some notes on readme files.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [x] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [x] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
