### PR TITLE
Update MONAI Bundle README for Path Nuclei Class, Path Nuclei Seg and…

### DIFF
--- a/models/pathology_nuclei_classification/configs/metadata.json
+++ b/models/pathology_nuclei_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "changelog": {
+        "0.0.8": "Update README Formatting",
         "0.0.7": "update benchmark on A100",
         "0.0.6": "adapt to BundleWorkflow interface",
         "0.0.5": "add name tag",

--- a/models/pathology_nuclei_classification/docs/README.md
+++ b/models/pathology_nuclei_classification/docs/README.md
@@ -137,9 +137,6 @@ A graph showing the validation F1-score over 50 epochs.
 ## MONAI Bundle Commands
 In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
-## MONAI Bundle Commands
-In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
-
 For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
 
 #### Execute training:

--- a/models/pathology_nuclei_classification/docs/README.md
+++ b/models/pathology_nuclei_classification/docs/README.md
@@ -1,11 +1,10 @@
-# Description
-A pre-trained model for classifying nuclei cells as the following types.
+# Model Overview
+A pre-trained model for classifying nuclei cells as the following types
  - Other
  - Inflammatory
  - Epithelial
  - Spindle-Shaped
 
-# Model Overview
 This model is trained using [DenseNet121](https://docs.monai.io/en/latest/networks.html#densenet121) over [ConSeP](https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet) dataset.
 
 ## Data
@@ -15,17 +14,6 @@ wget https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/consep_dataset.zip
 unzip -q consep_dataset.zip
 ```
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_dataset.jpeg)<br/>
-
-## Training configuration
-The training was performed with the following:
-
-- GPU: at least 12GB of GPU memory
-- Actual Model Input: 4 x 128 x 128
-- AMP: True
-- Optimizer: Adam
-- Learning Rate: 1e-4
-- Loss: torch.nn.CrossEntropyLoss
-
 
 ### Preprocessing
 After [downloading this dataset](https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/consep_dataset.zip),
@@ -84,13 +72,23 @@ Example `dataset.json` in output folder:
 }
 ```
 
+## Training configuration
+The training was performed with the following:
 
-## Input and output formats
-### Input: 4 channels
+- GPU: at least 12GB of GPU memory
+- Actual Model Input: 4 x 128 x 128
+- AMP: True
+- Optimizer: Adam
+- Learning Rate: 1e-4
+- Loss: torch.nn.CrossEntropyLoss
+
+## Input
+4 channels
 - 3 RGB channels
 - 1 signal channel (label mask)
 
-### Output: 4 channels
+## Output
+4 channels
  - 0 = Other
  - 1 = Inflammatory
  - 2 = Epithelial
@@ -98,7 +96,7 @@ Example `dataset.json` in output folder:
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_in_out.jpeg)
 
-## Scores
+## Performance
 This model achieves the following F1 score on the validation data provided as part of the dataset:
 
 - Train F1 score = 0.941
@@ -125,54 +123,54 @@ Confusion Metrics for <b>Training</b> for individual classes are (at epoch 50):
 
 
 
-## Training Performance
+#### Training Loss and F1
 A graph showing the training Loss and F1-score over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_loss_v2.png) <br>
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_train_f1_v2.png) <br>
 
-## Validation Performance
+#### Validation F1
 A graph showing the validation F1-score over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_classification_val_f1_v2.png) <br>
 
 
-## commands example
-Execute training:
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
+
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training:
 
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
-Override the `train` config to execute multi-GPU training:
+#### Override the `train` config to execute multi-GPU training:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
 ```
 
-Please note that the distributed training related options depend on the actual running environment, thus you may need to remove `--standalone`, modify `--nnodes` or do some other necessary changes according to the machine you used.
-Please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) for more details.
+Please note that the distributed training-related options depend on the actual running environment; thus, users may need to remove `--standalone`, modify `--nnodes`, or do some other necessary changes according to the machine used. For more details, please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
 
-Override the `train` config to execute evaluation with the trained model:
+#### Override the `train` config to execute evaluation with the trained model:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
+#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
 
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json','configs/multi_gpu_evaluate.json']"
 ```
 
-Execute inference:
+#### Execute inference:
 
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```
-
-# Disclaimer
-This is an example, not to be used for diagnostic purposes.
 
 # References
 [1] S. Graham, Q. D. Vu, S. E. A. Raza, A. Azam, Y-W. Tsang, J. T. Kwak and N. Rajpoot. "HoVer-Net: Simultaneous Segmentation and Classification of Nuclei in Multi-Tissue Histology Images." Medical Image Analysis, Sept. 2019. [[doi](https://doi.org/10.1016/j.media.2019.101563)]

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
-    "version": "0.1.5",
+    "version": "0.1.6",
     "changelog": {
+        "0.1.6": "Update README Formatting",
         "0.1.5": "update benchmark on A100",
         "0.1.4": "adapt to BundleWorkflow interface",
         "0.1.3": "add name tag",

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -1,8 +1,5 @@
 # Model Overview
-
 A pre-trained model for simultaneous segmentation and classification of nuclei within multi-tissue histology images based on CoNSeP data. The details of the model can be found in [1].
-
-## Workflow
 
 The model is trained to simultaneous segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, it uses [270, 270] and [80, 80] for `patch_size` and `out_size` respectively. If "fast" mode is specified, it uses [256, 256] and [164, 164] for `patch_size` and `out_size` respectively. The results we show below are based on the "fast" model.
 
@@ -24,6 +21,8 @@ The training data is from <https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet
 - Size: 41 image tiles (2009 patches)
 
 The provided labelled data was partitioned, based on the original split, into training (27 tiles) and testing (14 tiles) datasets.
+
+### Preprocessing
 
 After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `your-concep-dataset-path`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net/blob/master/extract_patches.py>. The command is like:
 
@@ -54,7 +53,7 @@ Output: a dictionary with the following keys:
 2. horizontal_vertical: predict the horizontal and vertical distances of nuclear pixels to their centres of mass
 3. type_prediction: predict the type of nucleus for each pixel
 
-## Model Performance
+## Performance
 
 The achieved metrics on the validation data are:
 
@@ -85,9 +84,12 @@ stage2:
 
 ![A graph showing the validation mean dice over 50 epochs in stage2](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_segmentation_classification_val_stage1_v2.png)
 
-## commands example
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
-Execute training, the evaluation in the training were evaluated on patches:
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training, the evaluation in the training were evaluated on patches:
 
 - Run first stage
 
@@ -101,7 +103,7 @@ python -m monai.bundle run --config_file configs/train.json --network_def#pretra
 python -m monai.bundle run --config_file configs/train.json --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
 
-Override the `train` config to execute multi-GPU training:
+#### Override the `train` config to execute multi-GPU training:
 
 - Run first stage
 
@@ -115,21 +117,17 @@ torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 4 --network_def#freeze_encoder False --network_def#pretrained_url None --stage 1
 ```
 
-Override the `train` config to execute evaluation with the trained model, here we evaluated dice from the whole input instead of the patches:
+#### Override the `train` config to execute evaluation with the trained model, here we evaluated dice from the whole input instead of the patches:
 
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-### Execute inference
+#### Execute inference
 
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```
-
-# Disclaimer
-
-This is an example, not to be used for diagnostic purposes.
 
 # References
 

--- a/models/pathology_nuclick_annotation/configs/metadata.json
+++ b/models/pathology_nuclick_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.0.7",
+    "version": "0.0.8",
     "changelog": {
+        "0.0.8": "Update README Formatting",
         "0.0.7": "Update with figure links",
         "0.0.6": "adapt to BundleWorkflow interface",
         "0.0.5": "add name tag",

--- a/models/pathology_nuclick_annotation/docs/README.md
+++ b/models/pathology_nuclick_annotation/docs/README.md
@@ -1,11 +1,10 @@
-# Description
+# Model Overview
 A pre-trained model for segmenting nuclei cells with user clicks/interactions.
 
 ![nuclick](https://github.com/mostafajahanifar/nuclick_torch/raw/master/docs/11.gif)
 ![nuclick](https://github.com/mostafajahanifar/nuclick_torch/raw/master/docs/33.gif)
 ![nuclick](https://github.com/mostafajahanifar/nuclick_torch/raw/master/docs/22.gif)
 
-# Model Overview
 This model is trained using [BasicUNet](https://docs.monai.io/en/latest/networks.html#basicunet) over [ConSeP](https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet) dataset.
 
 ## Data
@@ -15,17 +14,6 @@ wget https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/consep_dataset.zip
 unzip -q consep_dataset.zip
 ```
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_dataset.jpeg)<br/>
-
-## Training configuration
-The training was performed with the following:
-
-- GPU: at least 12GB of GPU memory
-- Actual Model Input: 5 x 128 x 128
-- AMP: True
-- Optimizer: Adam
-- Learning Rate: 1e-4
-- Loss: DiceLoss
-
 
 ### Preprocessing
 After [downloading this dataset](https://warwick.ac.uk/fac/cross_fac/tia/data/hovernet/consep_dataset.zip),
@@ -84,74 +72,81 @@ Example dataset.json
 }
 ```
 
+## Training configuration
+The training was performed with the following:
 
-## Input and output formats
-### Input: 5 channels
+- GPU: at least 12GB of GPU memory
+- Actual Model Input: 5 x 128 x 128
+- AMP: True
+- Optimizer: Adam
+- Learning Rate: 1e-4
+- Loss: DiceLoss
+
+
+## Input
+5 channels
 - 3 RGB channels
 - +ve signal channel (this nuclei)
 - -ve signal channel (other nuclei)
 
-### Output: 2 channels
+## Output
+2 channels
  - 0 = Background
  - 1 = Nuclei
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_train_in_out.jpeg)
 
-## Scores
+
+## Performance
 This model achieves the following Dice score on the validation data provided as part of the dataset:
 
 - Train Dice score = 0.89
 - Validation Dice score = 0.85
 
 
-## Training Performance
+#### Training Loss and Dice
 A graph showing the training Loss and Dice over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_train_loss.jpeg) <br>
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_train_dice.jpeg) <br>
 
-## Validation Performance
+#### Validation Dice
 A graph showing the validation mean Dice over 50 epochs.
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_pathology_nuclick_annotation_val_dice.jpeg) <br>
 
 
-## commands example
-Execute training:
+## MONAI Bundle Commands
+In addition to the Pythonic APIs, a few command line interfaces (CLI) are provided to interact with the bundle. The CLI supports flexible use cases, such as overriding configs at runtime and predefining arguments in a file.
 
+For more details usage instructions, visit the [MONAI Bundle Configuration Page](https://docs.monai.io/en/latest/config_syntax.html).
+
+#### Execute training:
 ```
 python -m monai.bundle run --config_file configs/train.json
 ```
 
-Override the `train` config to execute multi-GPU training:
-
+#### Override the `train` config to execute multi-GPU training:
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']"
 ```
 
-Please note that the distributed training related options depend on the actual running environment, thus you may need to remove `--standalone`, modify `--nnodes` or do some other necessary changes according to the machine you used.
-Please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) for more details.
+Please note that the distributed training-related options depend on the actual running environment; thus, users may need to remove `--standalone`, modify `--nnodes`, or do some other necessary changes according to the machine used. For more details, please refer to [pytorch's official tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html).
 
-Override the `train` config to execute evaluation with the trained model:
-
+#### Override the `train` config to execute evaluation with the trained model:
 ```
 python -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json']"
 ```
 
-Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
-
+#### Override the `train` config and `evaluate` config to execute multi-GPU evaluation:
 ```
 torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/evaluate.json','configs/multi_gpu_evaluate.json']"
 ```
 
-Execute inference:
-
+#### Execute inference:
 ```
 python -m monai.bundle run --config_file configs/inference.json
 ```
-
-# Disclaimer
-This is an example, not to be used for diagnostic purposes.
 
 # References
 [1] Koohbanani, Navid Alemi, et al. "NuClick: a deep learning framework for interactive segmentation of microscopic images." Medical Image Analysis 65 (2020): 101771. https://arxiv.org/abs/2005.14511.

--- a/models/wholeBody_ct_segmentation/configs/metadata.json
+++ b/models/wholeBody_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "changelog": {
+        "0.1.3": "Update README Formatting",
         "0.1.2": "Update figure with links",
         "0.1.1": "adapt to BundleWorkflow interface and val metric",
         "0.1.0": "complete the model package",

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -1,14 +1,13 @@
 # Model Overview
-
 Body CT segmentation models are evolving. Starting from abdominal multi-organ segmentation model [1]. Now the community is developing hundreds of target anatomies. In this bundle, we provide re-trained models for (3D) segmentation of 104 whole-body segments.
 
 This model is trained using the SegResNet [3] network. The model is trained using TotalSegmentator datasets [2].
 
-![structures](https://github.com/wasserth/TotalSegmentator/blob/master/resources/imgs/overview_classes.png)
+![structures](https://raw.githubusercontent.com/wasserth/TotalSegmentator/master/resources/imgs/overview_classes.png)
 
 Figure source from the TotalSegmentator [2].
 
-## MONAI Label Showcase
+### MONAI Label Showcase
 
 - We highlight the use of this bundle to use and visualize in MONAI Label + 3D Slicer integration.
 
@@ -51,6 +50,8 @@ One channel
 - Label 0: Background (everything else)
 - label 1-105: Foreground classes (104)
 
+## Resource Requirements and Latency Benchmarks
+
 ### High-Resolution and Low-Resolution Models
 
 We retrained two versions of the totalSegmentator models, following the original paper and implementation.
@@ -64,13 +65,11 @@ In MONAI Label use case, users can set the parameter in 3D Slicer plugin to cont
   - 1.5 mm model: [Download link](https://drive.google.com/file/d/1PHpFWboimEXmMSe2vBra6T8SaCMC2SHT/view?usp=share_link)
   - 3.0 mm model: [Download link](https://drive.google.com/file/d/1c3osYscnr6710ObqZZS8GkZJQlWlc7rt/view?usp=share_link)
 
-### Resource Requirements and Latency Benchmarks
-
 Latencies and memory performance of using the bundle with MONAI Label:
 
 Tested Image Dimension: **(512, 512, 397)**, the slice thickness is **1.5mm** in this case. After resample to **1.5** isotropic resolution, the dimension is   **(287, 287, 397)**
 
-## 1.5 mm (highres) model (Single Model with 104 foreground classes)
+### 1.5 mm (highres) model (Single Model with 104 foreground classes)
 
 Benchmarking on GPU: Memory: **28.73G**
 
@@ -80,7 +79,7 @@ Benchmarking on CPU: Memory: **26G**
 
 - `++ Latencies => Total: 38.3108; Pre: 1.6643; Inferer: 30.3018; Invert: 0.0000; Post: 6.1656; Write: 0.1786`
 
-## 3.0 mm (lowres) model (single model with 104 foreground classes)
+### 3.0 mm (lowres) model (single model with 104 foreground classes)
 
 GPU: Memory: **5.89G**
 

--- a/models/wholeBody_ct_segmentation/docs/README.md
+++ b/models/wholeBody_ct_segmentation/docs/README.md
@@ -91,13 +91,13 @@ CPU: Memory: **2.3G**
 
 ## Performance
 
-- 1.5 mm Model Training
+### 1.5 mm Model Training
 
-  - Training Accuracy
+#### Training Accuracy
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_train_accuracy.png) <br>
 
-  - Validation Dice
+#### Validation Dice
 
 ![](https://developer.download.nvidia.com/assets/Clara/Images/monai_wholeBody_ct_segmentation_15mm_validation.png) <br>
 


### PR DESCRIPTION
Fixed formatting issues with multiple bundles (Path Nuclei Class, Path Nuclei Seg and Class, Path Nuclick Annotation, and wholeBody CT Seg)

### Description
Update README formats to be consistent across all new bundles

### Status
Ready

### Please ensure all the checkboxes:
- [X] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.


