### PR TITLE
update README in `pathology_nuclei_segmentation_classification`

### DIFF
--- a/models/pathology_nuclei_segmentation_classification/configs/evaluate.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/evaluate.json
@@ -90,7 +90,20 @@
         },
         {
             "_target_": "StatsHandler",
-            "output_transform": "$lambda x: None"
+            "output_transform": "$lambda x: None",
+            "iteration_log": false
+        },
+        {
+            "_target_": "MetricsSaver",
+            "save_dir": "@output_dir",
+            "metrics": [
+                "val_mean_dice"
+            ],
+            "metric_details": [
+                "val_mean_dice"
+            ],
+            "batch_transform": "$monai.handlers.from_engine(['image_meta_dict'])",
+            "summary_ops": "*"
         }
     ],
     "validate#inferer": {

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "changelog": {
+        "0.1.8": "modify readme",
         "0.1.7": "Update README Formatting",
         "0.1.6": "add non-deterministic note",
         "0.1.5": "update benchmark on A100",

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -1,8 +1,7 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
-    "version": "0.1.8",
+    "version": "0.1.7",
     "changelog": {
-        "0.1.8": "modify readme",
         "0.1.7": "Update README Formatting",
         "0.1.6": "add non-deterministic note",
         "0.1.5": "update benchmark on A100",

--- a/models/pathology_nuclei_segmentation_classification/configs/metadata.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/metadata.json
@@ -2,7 +2,7 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_hovernet_20221124.json",
     "version": "0.1.8",
     "changelog": {
-        "0.1.8": "modify readme",
+        "0.1.8": "Update README for pretrained weights and save metrics in evaluate",
         "0.1.7": "Update README Formatting",
         "0.1.6": "add non-deterministic note",
         "0.1.5": "update benchmark on A100",

--- a/models/pathology_nuclei_segmentation_classification/configs/train.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/train.json
@@ -32,7 +32,7 @@
         "mode": "@hovernet_mode",
         "in_channels": 3,
         "out_classes": 5,
-        "adapt_standard_resnet": true,
+        "adapt_standard_resnet": false,
         "pretrained_url": null,
         "freeze_encoder": true
     },

--- a/models/pathology_nuclei_segmentation_classification/configs/train.json
+++ b/models/pathology_nuclei_segmentation_classification/configs/train.json
@@ -32,7 +32,7 @@
         "mode": "@hovernet_mode",
         "in_channels": 3,
         "out_classes": 5,
-        "adapt_standard_resnet": false,
+        "adapt_standard_resnet": true,
         "pretrained_url": null,
         "freeze_encoder": true
     },

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -11,7 +11,7 @@ There are two training modes in total. If "original" mode is specified, [270, 27
 In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) and [torchvison](https://pytorch.org/vision/stable/_modules/torchvision/models/resnet.html#ResNet18_Weights) also provide pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
-If you want to train the first stage with pre-trained weights, just specify `--network_def#pretrained_url your-pretrain-weights-url` in the training command below.
+If you want to train the first stage with pre-trained weights, just specify `--network_def#pretrained_url <your pretrain weights URL>` in the training command below.
 
 ![Model workflow](https://developer.download.nvidia.com/assets/Clara/Images/monai_hovernet_pipeline.png)
 
@@ -27,10 +27,10 @@ The provided labelled data was partitioned, based on the original split, into tr
 
 ### Preprocessing
 
-After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `your-concep-dataset-path`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net/blob/master/extract_patches.py>. The command is like:
+After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `<your concep dataset path>`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net/blob/master/extract_patches.py>. The command is like:
 
 ```
-python scripts/prepare_patches.py --root your-concep-dataset-path
+python scripts/prepare_patches.py --root <your concep dataset path>
 ```
 
 ## Training configuration

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -1,12 +1,10 @@
 # Model Overview
 A pre-trained model for simultaneous segmentation and classification of nuclei within multi-tissue histology images based on CoNSeP data. The details of the model can be found in [1].
 
-The model is trained to simultaneously segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights on the [ImageNet dataset](https://ieeexplore.ieee.org/document/5206848), trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
+The model is trained to simultaneously segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights, trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
-The first stage is trained with pre-trained weights from some internal data.The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
+In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
-
-`PRETRAIN_MODEL_URL` is "https://drive.google.com/u/1/uc?id=1KntZge40tAHgyXmHYVqZZ5d2p_4Qr2l5&export=download" which can be used in bash code below.
 
 ![Model workflow](https://developer.download.nvidia.com/assets/Clara/Images/monai_hovernet_pipeline.png)
 
@@ -25,7 +23,7 @@ The provided labelled data was partitioned, based on the original split, into tr
 After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `your-concep-dataset-path`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net/blob/master/extract_patches.py>. The command is like:
 
 ```
-python scripts/prepare_patches.py -root your-concep-dataset-path
+python scripts/prepare_patches.py --root your-concep-dataset-path
 ```
 
 ## Training configuration
@@ -56,9 +54,9 @@ Fast mode:
 - PQ: 0.4973
 - F1d: 0.7417
 
-Note: Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
-
-Please note that this bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
+Note:
+- Binary Dice is calculated based on the whole input. PQ and F1d were calculated from https://github.com/vqdang/hover_net#inference.
+- This bundle is non-deterministic because of the bilinear interpolation used in the network. Therefore, reproducing the training process may not get exactly the same performance.
 Please refer to https://pytorch.org/docs/stable/notes/randomness.html#reproducibility for more details about reproducibility.
 
 #### Training Loss and Dice
@@ -88,6 +86,7 @@ For more details usage instructions, visit the [MONAI Bundle Configuration Page]
 ```
 python -m monai.bundle run --config_file configs/train.json --network_def#pretrained_url `PRETRAIN_MODEL_URL` --stage 0
 ```
+Here `PRETRAIN_MODEL_URL` can be "https://drive.google.com/u/1/uc?id=1KntZge40tAHgyXmHYVqZZ5d2p_4Qr2l5&export=download".
 
 - Run second stage
 ```

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -84,7 +84,7 @@ For more details usage instructions, visit the [MONAI Bundle Configuration Page]
 
 - Run first stage
 ```
-python -m monai.bundle run --config_file configs/train.json --network_def#pretrained_url `PRETRAIN_MODEL_URL` --stage 0
+python -m monai.bundle run --config_file configs/train.json --network_def#pretrained_url $PRETRAIN_MODEL_URL --stage 0
 ```
 Here `PRETRAIN_MODEL_URL` can be "https://download.pytorch.org/models/resnet50-11ad3fa6.pth".
 
@@ -97,7 +97,7 @@ python -m monai.bundle run --config_file configs/train.json --network_def#freeze
 
 - Run first stage
 ```
-torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 8 --network_def#freeze_encoder True --network_def#pretrained_url `PRETRAIN_MODEL_URL --stage 0
+torchrun --standalone --nnodes=1 --nproc_per_node=2 -m monai.bundle run --config_file "['configs/train.json','configs/multi_gpu_train.json']" --batch_size 8 --network_def#freeze_encoder True --network_def#pretrained_url $PRETRAIN_MODEL_URL --stage 0
 ```
 
 - Run second stage

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -11,7 +11,7 @@ There are two training modes in total. If "original" mode is specified, [270, 27
 In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) and [torchvison](https://pytorch.org/vision/stable/_modules/torchvision/models/resnet.html#ResNet18_Weights) also provide pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
-If you want to train the first stage with pre-trained weights, just specify `--network_def#pretrained_url <your pretrain weights URL>` in the training command below.
+If you want to train the first stage with pre-trained weights, just specify `--network_def#pretrained_url <your pretrain weights URL>` in the training command below, such as [ImageNet](https://download.pytorch.org/models/resnet18-f37072fd.pth).
 
 ![Model workflow](https://developer.download.nvidia.com/assets/Clara/Images/monai_hovernet_pipeline.png)
 

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -8,7 +8,7 @@ The model is trained to simultaneously segment and classify nuclei, and a two-st
 
 There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
-In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) and [torchvison](https://pytorch.org/vision/stable/_modules/torchvision/models/resnet.html#ResNet18_Weights) also provide pre-trained weights but for non-commercial use.
+In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net) and [torchvison](https://pytorch.org/vision/stable/_modules/torchvision/models/resnet.html#ResNet18_Weights) also provide pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
 If you want to train the first stage with pre-trained weights, just specify `--network_def#pretrained_url <your pretrain weights URL>` in the training command below, such as [ImageNet](https://download.pytorch.org/models/resnet18-f37072fd.pth).
@@ -27,7 +27,7 @@ The provided labelled data was partitioned, based on the original split, into tr
 
 ### Preprocessing
 
-After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `<your concep dataset path>`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net/blob/master/extract_patches.py>. The command is like:
+After download the datasets, please run `scripts/prepare_patches.py` to prepare patches from tiles. Prepared patches are saved in `<your concep dataset path>`/Prepared. The implementation is referring to <https://github.com/vqdang/hover_net>. The command is like:
 
 ```
 python scripts/prepare_patches.py --root <your concep dataset path>

--- a/models/pathology_nuclei_segmentation_classification/docs/README.md
+++ b/models/pathology_nuclei_segmentation_classification/docs/README.md
@@ -3,7 +3,7 @@ A pre-trained model for simultaneous segmentation and classification of nuclei w
 
 The model is trained to simultaneously segment and classify nuclei. Training is done via a two-stage approach. First initialized the model with pre-trained weights, trained only the decoders for the first 50 epochs, and then fine-tuned all layers for another 50 epochs. There are two training modes in total. If "original" mode is specified, [270, 270] and [80, 80] are used for `patch_size` and `out_size` respectively. If "fast" mode is specified, [256, 256] and [164, 164] are used for `patch_size` and `out_size` respectively. The results shown below are based on the "fast" mode.
 
-In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) also provides pre-trained weights but for non-commercial use.
+In this bundle, the first stage is trained with pre-trained weights from some internal data. The [original author's repo](https://github.com/vqdang/hover_net#data-format) and [torchvison](https://pytorch.org/vision/stable/_modules/torchvision/models/resnet.html#ResNet18_Weights) also provide pre-trained weights but for non-commercial use.
 Each user is responsible for checking the content of models/datasets and the applicable licenses and determining if suitable for the intended use.
 
 ![Model workflow](https://developer.download.nvidia.com/assets/Clara/Images/monai_hovernet_pipeline.png)
@@ -86,7 +86,7 @@ For more details usage instructions, visit the [MONAI Bundle Configuration Page]
 ```
 python -m monai.bundle run --config_file configs/train.json --network_def#pretrained_url `PRETRAIN_MODEL_URL` --stage 0
 ```
-Here `PRETRAIN_MODEL_URL` can be "https://drive.google.com/u/1/uc?id=1KntZge40tAHgyXmHYVqZZ5d2p_4Qr2l5&export=download".
+Here `PRETRAIN_MODEL_URL` can be "https://download.pytorch.org/models/resnet50-11ad3fa6.pth".
 
 - Run second stage
 ```


### PR DESCRIPTION
Fixes # .

### Description
Now in `pathology_nuclei_segmentation_classification`, we provided the link of pre-trained weights from [HoVerNet repo](https://github.com/vqdang/hover_net#data-format). Just remove the URL.
- Update README to make it clearer.
- Add `MetricSaver` in the evaluation.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
