### PR TITLE
Update `wholeBody_ct_segmentation`

### DIFF
--- a/models/wholeBody_ct_segmentation/configs/evaluate.json
+++ b/models/wholeBody_ct_segmentation/configs/evaluate.json
@@ -9,30 +9,17 @@
             },
             {
                 "_target_": "Invertd",
-                "keys": [
-                    "pred",
-                    "label"
-                ],
+                "keys": "pred",
                 "transform": "@validate#preprocessing",
                 "orig_keys": "image",
                 "meta_key_postfix": "meta_dict",
-                "nearest_interp": [
-                    true,
-                    true
-                ],
+                "nearest_interp": true,
                 "to_tensor": true
             },
             {
                 "_target_": "AsDiscreted",
-                "keys": [
-                    "pred",
-                    "label"
-                ],
-                "argmax": [
-                    true,
-                    false
-                ],
-                "to_onehot": 105
+                "keys": "pred",
+                "argmax": true
             },
             {
                 "_target_": "SaveImaged",
@@ -61,8 +48,7 @@
             "_target_": "MetricsSaver",
             "save_dir": "@output_dir",
             "metrics": [
-                "val_mean_dice",
-                "val_acc"
+                "val_mean_dice"
             ],
             "metric_details": [
                 "val_mean_dice"

--- a/models/wholeBody_ct_segmentation/configs/train.json
+++ b/models/wholeBody_ct_segmentation/configs/train.json
@@ -253,30 +253,18 @@
             },
             {
                 "_target_": "EnsureTyped",
-                "keys": [
-                    "image",
-                    "label"
-                ]
+                "keys": "image"
             },
             {
                 "_target_": "Orientationd",
-                "keys": [
-                    "image",
-                    "label"
-                ],
+                "keys": "image",
                 "axcodes": "RAS"
             },
             {
                 "_target_": "Spacingd",
-                "keys": [
-                    "image",
-                    "label"
-                ],
+                "keys": "image",
                 "pixdim": "@pixdim",
-                "mode": [
-                    "bilinear",
-                    "nearest"
-                ]
+                "mode": "bilinear"
             },
             {
                 "_target_": "Identityd",
@@ -290,10 +278,7 @@
             },
             {
                 "_target_": "CropForegroundd",
-                "keys": [
-                    "image",
-                    "label"
-                ],
+                "keys": "image",
                 "source_key": "image",
                 "margin": 10,
                 "k_divisible": [
@@ -308,18 +293,6 @@
                     "image"
                 ],
                 "sigma": 0.4
-            },
-            {
-                "_target_": "CenterSpatialCropd",
-                "keys": [
-                    "image",
-                    "label"
-                ],
-                "roi_size": [
-                    160,
-                    160,
-                    160
-                ]
             }
         ],
         "preprocessing": {
@@ -328,6 +301,11 @@
             "lazy_evaluation": "@lazy",
             "override_keys": ["image", "label"],
             "overrides": "@overrides"
+        },
+        "preprocessing_inverse": {
+            "_target_": "Compose",
+            "transforms": "@validate#transforms",
+            "lazy_evaluation": false
         },
         "postprocessing": {
             "_target_": "Compose",
@@ -345,6 +323,15 @@
                     "argmax": [
                         true
                     ]
+                },
+                {
+                    "_target_": "Invertd",
+                    "keys": "pred",
+                    "transform": "@validate#preprocessing_inverse",
+                    "orig_keys": "image",
+                    "meta_key_postfix": "meta_dict",
+                    "nearest_interp": true,
+                    "to_tensor": true
                 }
             ]
         },

--- a/models/wholeBody_ct_segmentation/configs/train.json
+++ b/models/wholeBody_ct_segmentation/configs/train.json
@@ -151,7 +151,10 @@
             "_target_": "Compose",
             "transforms": "$@train#deterministic_transforms + @train#random_transforms",
             "lazy_evaluation": "@lazy",
-            "override_keys": ["image", "label"],
+            "override_keys": [
+                "image",
+                "label"
+            ],
             "overrides": "@overrides"
         },
         "dataset": {
@@ -299,7 +302,10 @@
             "_target_": "Compose",
             "transforms": "@validate#transforms",
             "lazy_evaluation": "@lazy",
-            "override_keys": ["image", "label"],
+            "override_keys": [
+                "image",
+                "label"
+            ],
             "overrides": "@overrides"
         },
         "preprocessing_inverse": {

--- a/models/wholeBody_ct_segmentation/configs/train.json
+++ b/models/wholeBody_ct_segmentation/configs/train.json
@@ -21,6 +21,8 @@
     "pixdim": "$[1.5, 1.5, 1.5] if @displayable_configs#highres else [3.0, 3.0, 3.0]",
     "modelname": "$'model.pt' if @displayable_configs#highres else 'model_lowres.pt'",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
+    "lazy": false,
+    "overrides": "${'mode': ('bilinear', 'nearest'), 'padding_mode': ('zeros', 'zeros'), 'dtype': torch.float32}",
     "network_def": {
         "_target_": "SegResNet",
         "spatial_dims": 3,
@@ -96,9 +98,10 @@
                 ]
             },
             {
-                "_target_": "NormalizeIntensityd",
+                "_target_": "ScaleIntensityd",
                 "keys": "image",
-                "nonzero": true
+                "minv": 0.0,
+                "maxv": 1.0
             },
             {
                 "_target_": "CropForegroundd",
@@ -120,12 +123,6 @@
                     "image"
                 ],
                 "sigma": 0.4
-            },
-            {
-                "_target_": "ScaleIntensityd",
-                "keys": "image",
-                "minv": -1.0,
-                "maxv": 1.0
             },
             {
                 "_target_": "EnsureTyped",
@@ -152,7 +149,10 @@
         ],
         "preprocessing": {
             "_target_": "Compose",
-            "transforms": "$@train#deterministic_transforms + @train#random_transforms"
+            "transforms": "$@train#deterministic_transforms + @train#random_transforms",
+            "lazy_evaluation": "@lazy",
+            "override_keys": ["image", "label"],
+            "overrides": "@overrides"
         },
         "dataset": {
             "_target_": "CacheDataset",
@@ -213,9 +213,11 @@
             }
         ],
         "key_metric": {
-            "train_accuracy": {
-                "_target_": "ignite.metrics.Accuracy",
-                "output_transform": "$monai.handlers.from_engine(['pred', 'label'])"
+            "train_mean_dice": {
+                "_target_": "MeanDice",
+                "include_background": false,
+                "output_transform": "$monai.handlers.from_engine(['pred', 'label'])",
+                "num_classes": 105
             }
         },
         "trainer": {
@@ -234,95 +236,98 @@
         }
     },
     "validate": {
+        "transforms": [
+            {
+                "_target_": "LoadImaged",
+                "keys": [
+                    "image",
+                    "label"
+                ]
+            },
+            {
+                "_target_": "EnsureChannelFirstd",
+                "keys": [
+                    "image",
+                    "label"
+                ]
+            },
+            {
+                "_target_": "EnsureTyped",
+                "keys": [
+                    "image",
+                    "label"
+                ]
+            },
+            {
+                "_target_": "Orientationd",
+                "keys": [
+                    "image",
+                    "label"
+                ],
+                "axcodes": "RAS"
+            },
+            {
+                "_target_": "Spacingd",
+                "keys": [
+                    "image",
+                    "label"
+                ],
+                "pixdim": "@pixdim",
+                "mode": [
+                    "bilinear",
+                    "nearest"
+                ]
+            },
+            {
+                "_target_": "Identityd",
+                "keys": "image"
+            },
+            {
+                "_target_": "ScaleIntensityd",
+                "keys": "image",
+                "minv": 0.0,
+                "maxv": 1.0
+            },
+            {
+                "_target_": "CropForegroundd",
+                "keys": [
+                    "image",
+                    "label"
+                ],
+                "source_key": "image",
+                "margin": 10,
+                "k_divisible": [
+                    96,
+                    96,
+                    96
+                ]
+            },
+            {
+                "_target_": "GaussianSmoothd",
+                "keys": [
+                    "image"
+                ],
+                "sigma": 0.4
+            },
+            {
+                "_target_": "CenterSpatialCropd",
+                "keys": [
+                    "image",
+                    "label"
+                ],
+                "roi_size": [
+                    160,
+                    160,
+                    160
+                ]
+            }
+        ],
         "preprocessing": {
             "_target_": "Compose",
-            "transforms": [
-                {
-                    "_target_": "LoadImaged",
-                    "keys": [
-                        "image",
-                        "label"
-                    ]
-                },
-                {
-                    "_target_": "EnsureChannelFirstd",
-                    "keys": [
-                        "image",
-                        "label"
-                    ]
-                },
-                {
-                    "_target_": "EnsureTyped",
-                    "keys": [
-                        "image",
-                        "label"
-                    ]
-                },
-                {
-                    "_target_": "Orientationd",
-                    "keys": [
-                        "image",
-                        "label"
-                    ],
-                    "axcodes": "RAS"
-                },
-                {
-                    "_target_": "Spacingd",
-                    "keys": [
-                        "image",
-                        "label"
-                    ],
-                    "pixdim": "@pixdim",
-                    "mode": [
-                        "bilinear",
-                        "nearest"
-                    ]
-                },
-                {
-                    "_target_": "NormalizeIntensityd",
-                    "keys": "image",
-                    "nonzero": true
-                },
-                {
-                    "_target_": "CropForegroundd",
-                    "keys": [
-                        "image",
-                        "label"
-                    ],
-                    "source_key": "image",
-                    "margin": 10,
-                    "k_divisible": [
-                        96,
-                        96,
-                        96
-                    ]
-                },
-                {
-                    "_target_": "GaussianSmoothd",
-                    "keys": [
-                        "image"
-                    ],
-                    "sigma": 0.4
-                },
-                {
-                    "_target_": "ScaleIntensityd",
-                    "keys": "image",
-                    "minv": -1.0,
-                    "maxv": 1.0
-                },
-                {
-                    "_target_": "CenterSpatialCropd",
-                    "keys": [
-                        "image",
-                        "label"
-                    ],
-                    "roi_size": [
-                        160,
-                        160,
-                        160
-                    ]
-                }
-            ]
+            "transforms": "@validate#transforms",
+            "lazy_evaluation": "@lazy",
+            "override_keys": ["image", "label"],
+            "overrides": "@overrides"
         },
         "postprocessing": {
             "_target_": "Compose",
@@ -335,14 +340,11 @@
                 {
                     "_target_": "AsDiscreted",
                     "keys": [
-                        "pred",
-                        "label"
+                        "pred"
                     ],
                     "argmax": [
-                        true,
-                        false
-                    ],
-                    "to_onehot": 105
+                        true
+                    ]
                 }
             ]
         },
@@ -392,13 +394,8 @@
             "val_mean_dice": {
                 "_target_": "MeanDice",
                 "include_background": false,
-                "output_transform": "$monai.handlers.from_engine(['pred', 'label'])"
-            }
-        },
-        "additional_metrics": {
-            "val_accuracy": {
-                "_target_": "ignite.metrics.Accuracy",
-                "output_transform": "$monai.handlers.from_engine(['pred', 'label'])"
+                "output_transform": "$monai.handlers.from_engine(['pred', 'label'])",
+                "num_classes": 105
             }
         },
         "evaluator": {
@@ -409,7 +406,6 @@
             "inferer": "@validate#inferer",
             "postprocessing": "@validate#postprocessing",
             "key_val_metric": "@validate#key_metric",
-            "additional_metrics": "@validate#additional_metrics",
             "val_handlers": "@validate#handlers",
             "amp": true
         }


### PR DESCRIPTION
### Description
While testing the lazy-resampling benchmark, I find that maybe there's room for improvement in the pre-processing. 
In this PR, I mainly update several places below:

- Remove `NormalizeIntensityd` since zeros aren't the background in the CT
- Move `ScaleIntensityd` in front of the `CropForeground` and change the value to 0-1 since we can only pad zero now in the lazy mode.
- Remove one-hot in the `AsDiscreted` which may save memory
- Update the metric in the training part from Accuracy to Dice
- Using the original label in the validation due to this [issue](https://github.com/Project-MONAI/model-zoo/issues/181#issuecomment-1510626663)

Note: the config was only tested on low resolution

cc @tangy5 @wyli 

### Status
**Work in progress**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
