### PR TITLE
Update Nuclei classification bundle to support deterministic eval

### DIFF
--- a/models/pathology_nuclei_classification/configs/evaluate.json
+++ b/models/pathology_nuclei_classification/configs/evaluate.json
@@ -67,7 +67,7 @@
     "initialize": [
         "$import sys",
         "$sys.path.append(@bundle_root)",
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
+        "$monai.utils.set_determinism(seed=123)",
         "$import scripts",
         "$monai.data.register_writer('json', scripts.ClassificationWriter)"
     ],

--- a/models/pathology_nuclei_classification/configs/inference.json
+++ b/models/pathology_nuclei_classification/configs/inference.json
@@ -108,7 +108,7 @@
         "amp": true
     },
     "initialize": [
-        "$setattr(torch.backends.cudnn, 'benchmark', True)",
+        "$monai.utils.set_determinism(seed=123)",
         "$import scripts",
         "$monai.data.register_writer('json', scripts.ClassificationWriter)"
     ],

--- a/models/pathology_nuclei_classification/configs/metadata.json
+++ b/models/pathology_nuclei_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "changelog": {
+        "0.1.1": "enable deterministic eval and inference",
         "0.1.0": "Update deterministic results",
         "0.0.9": "Update README Formatting",
         "0.0.8": "enable deterministic training",

--- a/models/pathology_nuclei_classification/configs/multi_gpu_evaluate.json
+++ b/models/pathology_nuclei_classification/configs/multi_gpu_evaluate.json
@@ -21,6 +21,7 @@
         "$import torch.distributed as dist",
         "$dist.is_initialized() or dist.init_process_group(backend='nccl')",
         "$torch.cuda.set_device(@device)",
+        "$monai.utils.set_determinism(seed=123)",
         "$import logging",
         "$@validate#evaluator.logger.setLevel(logging.WARNING if dist.get_rank() > 0 else logging.INFO)",
         "$import scripts",


### PR DESCRIPTION
### Description
This PR is used to update the `pathology_nuclei_classification` bundle to support deterministic evaluation and inference.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
