### PR TITLE
Update endoscopic tool segmentation on pre-trained weights loader

### DIFF
--- a/models/endoscopic_tool_segmentation/configs/metadata.json
+++ b/models/endoscopic_tool_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.1",
+    "version": "0.5.2",
     "changelog": {
+        "0.5.2": "remove the CheckpointLoader from the train.json",
         "0.5.1": "add RAM warning",
         "0.5.0": "update TensorRT descriptions",
         "0.4.9": "update the model weights",

--- a/models/endoscopic_tool_segmentation/configs/train.json
+++ b/models/endoscopic_tool_segmentation/configs/train.json
@@ -138,16 +138,6 @@
         },
         "handlers": [
             {
-                "_target_": "CheckpointLoader",
-                "_disabled_": "@use_imagenet_pretrain",
-                "load_path": "/path/to/local/weight/model.pt",
-                "load_dict": {
-                    "model": "@network"
-                },
-                "strict": false,
-                "map_location": "@device"
-            },
-            {
                 "_target_": "ValidationHandler",
                 "validator": "@validate#evaluator",
                 "epoch_level": true,

--- a/models/endoscopic_tool_segmentation/docs/README.md
+++ b/models/endoscopic_tool_segmentation/docs/README.md
@@ -6,10 +6,24 @@ The [PyTorch model](https://drive.google.com/file/d/1I7UtWDKDEcezMqYiA-i_hsRTCrv
 ![image](https://developer.download.nvidia.com/assets/Clara/Images/monai_endoscopic_tool_segmentation_workflow.png)
 
 ## Pre-trained weights
-A pre-trained encoder weights would benefit the model training. In this bundle, the encoder is trained with pre-trained weights from some internal data. For convenience, we provide two options in `configs/train.json` to enable users to load pre-trained weights:
+A pre-trained encoder weights would benefit the model training. In this bundle, the encoder is trained with pre-trained weights from some internal data. We provide two options to enable users to load pre-trained weights:
 
 1. Via setting the `use_imagenet_pretrain` parameter in the config file to `True`, [ImageNet](https://ieeexplore.ieee.org/document/5206848) pre-trained weights from the [EfficientNet-PyTorch repo](https://github.com/lukemelas/EfficientNet-PyTorch) can be loaded. Please note that these weights are for non-commercial use. Each user is responsible for checking the content of the models/datasets and the applicable licenses and determining if suitable for the intended use.
-2. Via updating the `load_path`  parameter of the `CheckpointLoader` in the config file, weights from a local path can be loaded.
+2. Via adding a `CheckpointLoader` as the first handler to the `handlers` section of the `train.json` config file, weights from a local path can be loaded. Here is an example `CheckpointLoader`:
+
+```json
+{
+    "_target_": "CheckpointLoader",
+    "load_path": "/path/to/local/weight/model.pt",
+    "load_dict": {
+        "model": "@network"
+    },
+    "strict": false,
+    "map_location": "@device"
+}
+```
+
+When executing the training command, if neither adding the `CheckpointLoader` to the `train.json` nor setting the `use_imagenet_pretrain` parameter to `True`, a training process would start from scratch.
 
 ## Data
 Datasets used in this work were provided by [Activ Surgical](https://www.activsurgical.com/).


### PR DESCRIPTION
Remove the `CheckpointLoader` in the `train.json` and add an explanation about how to load pre-trained encoder weights to the bundle.

### Description
A few sentences describing the changes proposed in this pull request.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
