### PR TITLE
Unify dataset dir for ldm bundles

### DIFF
--- a/ci/install_scripts/install_brats_mri_axial_slices_generative_diffusion.sh
+++ b/ci/install_scripts/install_brats_mri_axial_slices_generative_diffusion.sh
@@ -9,6 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# install cython to avoid error:
-# https://github.com/Project-MONAI/model-zoo/actions/runs/4980530305/jobs/8913560199#step:2:550
-pip install git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1
+pip install --disable-pip-version-check --no-deps git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1

--- a/ci/install_scripts/install_brats_mri_generative_diffusion_dependency.sh
+++ b/ci/install_scripts/install_brats_mri_generative_diffusion_dependency.sh
@@ -9,6 +9,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# install cython to avoid error:
-# https://github.com/Project-MONAI/model-zoo/actions/runs/4980530305/jobs/8913560199#step:2:550
-pip install git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1
+pip install --disable-pip-version-check --no-deps git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1

--- a/models/brats_mri_axial_slices_generative_diffusion/configs/inference.json
+++ b/models/brats_mri_axial_slices_generative_diffusion/configs/inference.json
@@ -103,6 +103,7 @@
     "generated_image_np": "$@generated_image[0,0].cpu().numpy().transpose(1, 0)[::-1, ::-1]",
     "img_pil": "$Image.fromarray(visualize_2d_image(@generated_image_np), 'RGB')",
     "run": [
+        "$@create_output_dir",
         "$@img_pil.save(@output_dir+'/synimg_'+@output_postfix+'.png')"
     ]
 }

--- a/models/brats_mri_axial_slices_generative_diffusion/configs/inference_autoencoder.json
+++ b/models/brats_mri_axial_slices_generative_diffusion/configs/inference_autoencoder.json
@@ -8,7 +8,7 @@
     ],
     "bundle_root": ".",
     "model_dir": "$@bundle_root + '/models'",
-    "dataset_dir": "@bundle_root",
+    "dataset_dir": "/workspace/data/medical",
     "output_dir": "$@bundle_root + '/output'",
     "create_output_dir": "$Path(@output_dir).mkdir(exist_ok=True)",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",

--- a/models/brats_mri_axial_slices_generative_diffusion/configs/metadata.json
+++ b/models/brats_mri_axial_slices_generative_diffusion/configs/metadata.json
@@ -1,10 +1,11 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_generator_ldm_20230507.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
+        "1.0.1": "fix inference folder error",
         "1.0.0": "Initial release"
     },
-    "monai_version": "1.2.0rc5",
+    "monai_version": "1.2.0rc7",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/brats_mri_axial_slices_generative_diffusion/configs/train_autoencoder.json
+++ b/models/brats_mri_axial_slices_generative_diffusion/configs/train_autoencoder.json
@@ -8,7 +8,7 @@
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
     "ckpt_dir": "$@bundle_root + '/models'",
     "tf_dir": "$@bundle_root + '/eval'",
-    "dataset_dir": "@bundle_root",
+    "dataset_dir": "/workspace/data/medical",
     "pretrained": false,
     "perceptual_loss_model_weights_path": null,
     "train_batch_size_img": 1,

--- a/models/brats_mri_axial_slices_generative_diffusion/configs/train_diffusion.json
+++ b/models/brats_mri_axial_slices_generative_diffusion/configs/train_diffusion.json
@@ -108,7 +108,7 @@
             "section": "training",
             "cache_rate": 1.0,
             "num_workers": 8,
-            "download": "@download_brats",
+            "download": false,
             "transform": "@train#preprocessing"
         },
         "dataloader": {

--- a/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
+++ b/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
@@ -20,11 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [BraTS 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865).**
 
 ## MONAI Generative Model Dependencies
-[MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) can be installed by
-```
-pip install lpips==0.1.4
-pip install git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1
-```
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) and [lpips](https://github.com/richzhang/PerceptualSimilarity). 
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
+++ b/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
@@ -20,7 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [BraTS 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865).**
 
 ## MONAI Generative Model Dependencies
-This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels). 
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels).
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
+++ b/models/brats_mri_axial_slices_generative_diffusion/docs/README.md
@@ -20,7 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [BraTS 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865).**
 
 ## MONAI Generative Model Dependencies
-This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) and [lpips](https://github.com/richzhang/PerceptualSimilarity). 
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels). 
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/brats_mri_generative_diffusion/configs/inference_autoencoder.json
+++ b/models/brats_mri_generative_diffusion/configs/inference_autoencoder.json
@@ -6,7 +6,7 @@
     ],
     "bundle_root": ".",
     "model_dir": "$@bundle_root + '/models'",
-    "dataset_dir": "@bundle_root",
+    "dataset_dir": "/workspace/data/medical",
     "output_dir": "$@bundle_root + '/output'",
     "create_output_dir": "$Path(@output_dir).mkdir(exist_ok=True)",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",

--- a/models/brats_mri_generative_diffusion/configs/metadata.json
+++ b/models/brats_mri_generative_diffusion/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_generator_ldm_20230507.json",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "changelog": {
+        "1.0.2": "unify dataset dir in different configs",
         "1.0.1": "update dependency, update trained model weights",
         "1.0.0": "Initial release"
     },

--- a/models/brats_mri_generative_diffusion/docs/README.md
+++ b/models/brats_mri_generative_diffusion/docs/README.md
@@ -20,11 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [Brats 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865) and have GPU with memory larger than 32G to enable larger networks and attention layers.**
 
 ## MONAI Generative Model Dependencies
-[MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) can be installed by
-```
-pip install lpips==0.1.4
-pip install git+https://github.com/Project-MONAI/GenerativeModels.git@0.2.1
-```
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) and [lpips](https://github.com/richzhang/PerceptualSimilarity). 
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/brats_mri_generative_diffusion/docs/README.md
+++ b/models/brats_mri_generative_diffusion/docs/README.md
@@ -20,7 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [Brats 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865) and have GPU with memory larger than 32G to enable larger networks and attention layers.**
 
 ## MONAI Generative Model Dependencies
-This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels). 
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels).
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/brats_mri_generative_diffusion/docs/README.md
+++ b/models/brats_mri_generative_diffusion/docs/README.md
@@ -20,7 +20,7 @@ An example result from inference is shown below:
 **This is a demonstration network meant to just show the training process for this sort of network with MONAI. To achieve better performance, users need to use larger dataset like [Brats 2021](https://www.synapse.org/#!Synapse:syn25829067/wiki/610865) and have GPU with memory larger than 32G to enable larger networks and attention layers.**
 
 ## MONAI Generative Model Dependencies
-This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels) and [lpips](https://github.com/richzhang/PerceptualSimilarity). 
+This bundle requires to install [MONAI generative models](https://github.com/Project-MONAI/GenerativeModels). 
 
 ## Data
 The training data is BraTS 2016 and 2017 from the Medical Segmentation Decathalon. Users can find more details on the dataset (`Task01_BrainTumour`) at http://medicaldecathlon.com/.

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.5",
+    "version": "0.4.6",
     "changelog": {
+        "0.4.6": "update to use rc7 which solves dynunet issue",
         "0.4.5": "remove error dollar symbol in readme",
         "0.4.4": "add RAM comsumption with Cachedataset",
         "0.4.3": "update ONNX-TensorRT descriptions",
@@ -22,7 +23,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0rc5",
+    "monai_version": "1.2.0rc7",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {


### PR DESCRIPTION
Fixes # .

### Description
This PR does the following changes:

1. for `spleen_deepedit_annotation`, since the network it used is failed in monai==1.2.0rc6, it used 1.2.0rc5 instead. Now the network issue has been fixed in monai==1.2.0rc7, I changed the lib version in metadata.
2. for `models/brats_mri_axial_slices_generative_diffusion/configs/inference.json`, there is an issue that the create folder command is not executed, and run the inference command will raise an error. cc @Can-Zhao 
3. for other changes, the purpose is to unify the default value of `dataset_dir`.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
