### PR TITLE
Corrected image size from 229 to 299 in metadata.json

### DIFF
--- a/models/breast_density_classification/configs/metadata.json
+++ b/models/breast_density_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.4",
+    "version": "0.1.5",
     "changelog": {
+        "0.1.5": "Fixed duplication of input output format section",
         "0.1.4": "Changed Readme",
         "0.1.3": "Change input_dim from 229 to 299",
         "0.1.2": "black autofix format and add name tag",

--- a/models/breast_density_classification/configs/metadata.json
+++ b/models/breast_density_classification/configs/metadata.json
@@ -37,8 +37,8 @@
                 "modality": "Mammogram",
                 "num_channels": 3,
                 "spatial_shape": [
-                    229,
-                    229
+                    299,
+                    299
                 ],
                 "dtype": "float32",
                 "value_range": [

--- a/models/breast_density_classification/configs/metadata.json
+++ b/models/breast_density_classification/configs/metadata.json
@@ -1,6 +1,6 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.2",
+    "version": "0.1.3",
     "changelog": {
         "0.1.2": "black autofix format and add name tag",
         "0.1.1": "update license files",

--- a/models/breast_density_classification/configs/metadata.json
+++ b/models/breast_density_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "changelog": {
+        "0.1.4": "Changed Readme",
         "0.1.3": "Change input_dim from 229 to 299",
         "0.1.2": "black autofix format and add name tag",
         "0.1.1": "update license files",

--- a/models/breast_density_classification/configs/metadata.json
+++ b/models/breast_density_classification/configs/metadata.json
@@ -2,6 +2,7 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
     "version": "0.1.3",
     "changelog": {
+        "0.1.3": "Change input_dim from 229 to 299",
         "0.1.2": "black autofix format and add name tag",
         "0.1.1": "update license files",
         "0.1.0": "complete the model package"

--- a/models/breast_density_classification/docs/README.md
+++ b/models/breast_density_classification/docs/README.md
@@ -6,9 +6,6 @@ This model is trained using transfer learning on InceptionV3. The model weights 
 A training pipeline will be added to the model zoo in near future.
 The bundle does not support torchscript.
 
-# Input and Output Formats
-The input image should have the size [299, 299, 3]. The output is an array with probabilities for each of the four class.
-
 # Sample Data
 In the folder `sample_data` few example input images are stored for each category of images. These images are stored in jpeg format for sharing purpose.
 

--- a/models/breast_density_classification/docs/README.md
+++ b/models/breast_density_classification/docs/README.md
@@ -2,12 +2,12 @@
 A pre-trained model for breast-density classification.
 
 # Model Overview
-This model is trained using transfer learning on InceptionV3. The model weights were fine tuned using the Mayo Clinic Data. The details of training and data is outlined in https://arxiv.org/abs/2202.08238.
-
+This model is trained using transfer learning on InceptionV3. The model weights were fine tuned using the Mayo Clinic Data. The details of training and data is outlined in https://arxiv.org/abs/2202.08238. The images should be resampled to a size [299, 299, 3] for training.
+A training pipeline will be added to the model zoo in near future.
 The bundle does not support torchscript.
 
 # Input and Output Formats
-The input image should have the size [3, 299, 299]. The output is an array with probabilities for each of the four class.
+The input image should have the size [299, 299, 3]. The output is an array with probabilities for each of the four class.
 
 # Sample Data
 In the folder `sample_data` few example input images are stored for each category of images. These images are stored in jpeg format for sharing purpose.


### PR DESCRIPTION
Fixes # .

### Description
Resolving issue #303 

### Status
**Ready*

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x ] In-line docstrings updated.
- [x ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
