### PR TITLE
461 add review pr guide [skip ci]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,8 +193,20 @@ Ideally, the new branch should be based on the latest `dev` branch.
 1. Reviewer and contributor may have discussions back and forth until all comments addressed.
 1. Wait for the pull request to be merged.
 
-[monai model zoo issue list]: https://github.com/Project-MONAI/model-zoo/issues
+## Reviewing pull requests
 
+All code review comments should be specific, constructive, and actionable.
+1. Check [the CI/CD status of the pull request][github ci], make sure all CI/CD tests passed before reviewing (contact the branch owner if needed).
+1. Read carefully the descriptions of the pull request and the files changed, write comments if needed.
+1. Make in-line comments to specific code segments, [request for changes](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-request-reviews) if needed.
+1. Review any further code changes until all comments addressed by the contributors.
+1. Comment to trigger `/black` for optional auto code formatting.
+1. [Maintainers] Review the changes and comment `/build` to trigger internal full tests.
+1. Merge the pull request to the dev branch.
+1. Close the corresponding task ticket on [the issue list][monai model zoo issue list].
+
+[github ci]: https://github.com/Project-MONAI/model-zoo/actions
+[monai model zoo issue list]: https://github.com/Project-MONAI/model-zoo/issues
 
 ## Validate and release
 


### PR DESCRIPTION
Fixes #461 .

### Description
This PR is used to enhance the contributing guide. A section called `Reviewing pull requests` is added.
This PR refers to:
https://github.com/Project-MONAI/MONAI/blob/60620e46645d131f3fe05e98f4c91e1fbda9bf13/CONTRIBUTING.md?plain=1#L328

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x] In-line docstrings updated.
