### PR TITLE
fix pythonpath for whole-brain-segmentation

### DIFF
--- a/models/wholeBrainSeg_Large_UNEST_segmentation/configs/metadata.json
+++ b/models/wholeBrainSeg_Large_UNEST_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "changelog": {
+        "0.2.3": "fix PYTHONPATH in readme.md",
         "0.2.2": "add name tag",
         "0.2.1": "fix license Copyright error",
         "0.2.0": "update license files",

--- a/models/wholeBrainSeg_Large_UNEST_segmentation/docs/README.md
+++ b/models/wholeBrainSeg_Large_UNEST_segmentation/docs/README.md
@@ -88,7 +88,7 @@ Download trained checkpoint model to ./model/model.pt:
 Add scripts component:  To run the workflow with customized components, PYTHONPATH should be revised to include the path to the customized component:
 
 ```
-export PYTHONPATH=$PYTHONPATH: '<path to the bundle root dir>/scripts'
+export PYTHONPATH=$PYTHONPATH: '<path to the bundle root dir>/'
 ```
 
 Execute Training:


### PR DESCRIPTION
Fixes #466.

### Description

As pointed out in issue #466, removing `scripts` from the path added in the `PYTHONPATH` makes the bundle work correctly.