### PR TITLE
481 rotation of output images in prostate mri anatomy

### DIFF
--- a/models/prostate_mri_anatomy/configs/inference.json
+++ b/models/prostate_mri_anatomy/configs/inference.json
@@ -5,8 +5,8 @@
     ],
     "bundle_root": "/workspace/data/prostate_mri_anatomy",
     "output_dir": "$@bundle_root + '/eval'",
-    "dataset_dir": "/workspace/data/prostate158/prostate158_train/",
-    "datalist": "$list(@dataset_dir + pd.read_csv(@dataset_dir + 'valid.csv').t2)",
+    "dataset_dir": "/workspace/data/prostate158/prostate158_test/",
+    "datalist": "$list(@dataset_dir + pd.read_csv(@dataset_dir + 'test.csv').t2)",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
     "network_def": {
         "_target_": "UNet",
@@ -115,6 +115,15 @@
                 ]
             },
             {
+                "_target_": "Invertd",
+                "keys": "pred",
+                "transform": "@preprocessing",
+                "orig_keys": "image",
+                "meta_key_postfix": "meta_dict",
+                "nearest_interp": false,
+                "to_tensor": true
+            },
+            {
                 "_target_": "SaveImaged",
                 "keys": "pred",
                 "resample": false,
@@ -127,6 +136,10 @@
         {
             "_target_": "CheckpointLoader",
             "load_path": "$@bundle_root + '/models/model.pt'",
+            "map_location": {
+                "_target_": "torch.device",
+                "device": "@device"
+        },
             "load_dict": {
                 "model": "@network"
             }

--- a/models/prostate_mri_anatomy/configs/inference.json
+++ b/models/prostate_mri_anatomy/configs/inference.json
@@ -139,7 +139,7 @@
             "map_location": {
                 "_target_": "torch.device",
                 "device": "@device"
-        },
+            },
             "load_dict": {
                 "model": "@network"
             }

--- a/models/prostate_mri_anatomy/configs/metadata.json
+++ b/models/prostate_mri_anatomy/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.3.2",
+    "version": "0.3.3",
     "changelog": {
+        "0.3.3": "add invertd transformation",
         "0.3.2": "add name tag",
         "0.3.1": "fix license Copyright error",
         "0.3.0": "update license files",

--- a/models/prostate_mri_anatomy/configs/metadata.json
+++ b/models/prostate_mri_anatomy/configs/metadata.json
@@ -15,7 +15,7 @@
     "numpy_version": "1.22.3",
     "optional_packages_version": {
         "nibabel": "3.2.2",
-        "itk": "5.2.1",
+        "itk": "5.3",
         "pytorch-ignite": "0.4.9",
         "pandas": "1.4.2"
     },


### PR DESCRIPTION
### Description
481-Rotation of output images in prostate_mri_anatomy

- The transformations applied to the test data during preprocessing are not reversed during postprocessing. Thus, the resulting predictions have a different rotation compared to the original images and labels. I added an 'invertd()' function that reverses all the traceable transformations in the preprocessing.
- Running the inference on a PC without a GPU leads to an error because the handlers function 'CheckpointLoader' attempts to load the model onto the GPU. I set the map_location argument to torch.device(device) so that it automatically loads the model onto the CPU when a GPU is not available.
- Additionally, I changed some of the config directories as they were referring to the validation dataset rather than the test dataset.

### Status
Ready

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [x] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [x] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
