### PR TITLE
Update import method for PyGithub [skip-gpu]

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -18,10 +18,11 @@ import shutil
 import subprocess
 from typing import List
 
-from github import Github
 from monai.apps.utils import download_url
 from monai.bundle.config_parser import ConfigParser
-from monai.utils import look_up_option
+from monai.utils import look_up_option, optional_import
+
+Github, _ = optional_import("github", name="Github")
 
 SUPPORTED_HASH_TYPES = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256, "sha512": hashlib.sha512}
 


### PR DESCRIPTION
### Description
This PR is used to fix the ci test issue, when the environment does not have `PyGithub`, running `ci/verify_bundle.py` will raise an error. However, not all tests require this library, thus it should be optional.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
