### PR TITLE
Using `EnsureChannelFirst` in `endoscopic_tool_segmentation`

### DIFF
--- a/models/endoscopic_tool_segmentation/configs/inference.json
+++ b/models/endoscopic_tool_segmentation/configs/inference.json
@@ -24,15 +24,13 @@
         "transforms": [
             {
                 "_target_": "LoadImaged",
-                "keys": [
-                    "image"
-                ]
+                "keys": "image",
+                "image_only": false
             },
             {
-                "_target_": "AsChannelFirstd",
-                "keys": [
-                    "image"
-                ]
+                "_target_": "EnsureChannelFirstd",
+                "keys": "image",
+                "channel_dim": -1
             },
             {
                 "_target_": "Resized",

--- a/models/endoscopic_tool_segmentation/configs/metadata.json
+++ b/models/endoscopic_tool_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "changelog": {
+        "0.5.5": "update AddChanneld with EnsureChannelFirstd and set image_only to False",
         "0.5.4": "fix the wrong GPU index issue of multi-node",
         "0.5.3": "remove error dollar symbol in readme",
         "0.5.2": "remove the CheckpointLoader from the train.json",
@@ -25,7 +26,7 @@
         "0.1.0": "complete the first version model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0",
+    "monai_version": "1.3.0rc1",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/endoscopic_tool_segmentation/configs/train.json
+++ b/models/endoscopic_tool_segmentation/configs/train.json
@@ -53,15 +53,18 @@
                 "keys": [
                     "image",
                     "label"
-                ]
+                ],
+                "image_only": false
             },
             {
-                "_target_": "AsChannelFirstd",
-                "keys": "image"
+                "_target_": "EnsureChannelFirstd",
+                "keys": "image",
+                "channel_dim": -1
             },
             {
-                "_target_": "AddChanneld",
-                "keys": "label"
+                "_target_": "EnsureChannelFirstd",
+                "keys": "label",
+                "channel_dim": "no_channel"
             },
             {
                 "_target_": "Resized",


### PR DESCRIPTION
Fixes https://github.com/Project-MONAI/MONAI/issues/7036.

### Description
Using `EnsureChannelFirst` in `endoscopic_tool_segmentation`.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [x] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
