### PR TITLE
Add option to validate at training start of deepedit

### DIFF
--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -12,10 +12,13 @@
 
 import argparse
 import os
+import re
 
 from bundle_custom_data import install_dependency_dict
 from utils import get_json_dict
 
+def is_commit_hash(s):
+    return bool(re.match('^[0-9a-f]{7,40}$', s))
 
 def get_requirements(bundle, models_path):
     """
@@ -29,7 +32,10 @@ def get_requirements(bundle, models_path):
         libs = []
         if "monai_version" in metadata.keys():
             monai_version = metadata["monai_version"]
-            libs.append(f"monai=={monai_version}")
+            if is_commit_hash(monai_version):
+                libs.append(f"git+https://github.com/Project-MONAI/MONAI@${monai_version}#egg=monai")
+            else:
+                libs.append(f"monai=={monai_version}")
         if "pytorch_version" in metadata.keys():
             pytorch_version = metadata["pytorch_version"]
             libs.append(f"torch=={pytorch_version}")

--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -12,13 +12,10 @@
 
 import argparse
 import os
-import re
 
 from bundle_custom_data import install_dependency_dict
 from utils import get_json_dict
 
-def is_commit_hash(s):
-    return bool(re.match('^[0-9a-f]{7,40}$', s))
 
 def get_requirements(bundle, models_path):
     """
@@ -32,10 +29,7 @@ def get_requirements(bundle, models_path):
         libs = []
         if "monai_version" in metadata.keys():
             monai_version = metadata["monai_version"]
-            if is_commit_hash(monai_version):
-                libs.append(f"git+https://github.com/Project-MONAI/MONAI@${monai_version}#egg=monai")
-            else:
-                libs.append(f"monai=={monai_version}")
+            libs.append(f"monai=={monai_version}")
         if "pytorch_version" in metadata.keys():
             pytorch_version = metadata["pytorch_version"]
             libs.append(f"torch=={pytorch_version}")

--- a/models/spleen_deepedit_annotation/configs/evaluate.json
+++ b/models/spleen_deepedit_annotation/configs/evaluate.json
@@ -24,7 +24,6 @@
                 "_target_": "SaveImaged",
                 "_disabled_": true,
                 "keys": "pred",
-                "meta_keys": "pred_meta_dict",
                 "output_dir": "@output_dir",
                 "resample": false,
                 "squeeze_end_dims": true
@@ -53,7 +52,7 @@
             "metric_details": [
                 "val_mean_dice"
             ],
-            "batch_transform": "$monai.handlers.from_engine(['image_meta_dict'])",
+            "batch_transform": "$lambda x: [xx['image'].meta for xx in x]",
             "summary_ops": "*"
         }
     ],

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -163,7 +163,6 @@
                 "keys": "pred",
                 "transform": "@preprocessing",
                 "orig_keys": "@image_key",
-                "meta_key_postfix": "meta_dict",
                 "nearest_interp": false,
                 "to_tensor": true
             },
@@ -175,7 +174,6 @@
             {
                 "_target_": "SaveImaged",
                 "keys": "pred",
-                "meta_keys": "pred_meta_dict",
                 "output_dir": "@output_dir",
                 "output_ext": "@output_ext",
                 "output_dtype": "@output_dtype",

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -1,6 +1,7 @@
 {
     "imports": [
         "$import glob",
+        "$import numpy",
         "$import os",
         "$import ignite"
     ],
@@ -8,7 +9,7 @@
     "image_key": "image",
     "output_dir": "$@bundle_root + '/eval'",
     "output_ext": ".nii.gz",
-    "output_dtype": "uint8",
+    "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
     "dataset_dir": "/workspace/Datasets/MSD_datasets/Task09_Spleen",

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -6,7 +6,6 @@
     ],
     "bundle_root": ".",
     "image_key": "image",
-    "label_key": "label",
     "output_dir": "$@bundle_root + '/eval'",
     "output_ext": ".nrrd",
     "output_dtype": "uint8",

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -7,10 +7,10 @@
     "bundle_root": ".",
     "image_key": "image",
     "output_dir": "$@bundle_root + '/eval'",
-    "output_ext": ".nrrd",
+    "output_ext": ".nii.gz",
     "output_dtype": "uint8",
-    "output_postfix": "seg",
-    "separate_folder": false,
+    "output_postfix": "trans",
+    "separate_folder": true,
     "dataset_dir": "/workspace/Datasets/MSD_datasets/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "label_names": {

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -5,7 +5,13 @@
         "$import ignite"
     ],
     "bundle_root": ".",
+    "image_key": "image",
+    "label_key": "label",
     "output_dir": "$@bundle_root + '/eval'",
+    "output_ext": ".nrrd",
+    "output_dtype": "uint8",
+    "output_postfix": "seg",
+    "separate_folder": false,
     "dataset_dir": "/workspace/Datasets/MSD_datasets/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "label_names": {
@@ -63,21 +69,21 @@
     "preprocessing_transforms": [
         {
             "_target_": "LoadImaged",
-            "keys": "image",
+            "keys": "@image_key",
             "reader": "ITKReader"
         },
         {
             "_target_": "EnsureChannelFirstd",
-            "keys": "image"
+            "keys": "@image_key"
         },
         {
             "_target_": "Orientationd",
-            "keys": "image",
+            "keys": "@image_key",
             "axcodes": "RAS"
         },
         {
             "_target_": "ScaleIntensityRanged",
-            "keys": "image",
+            "keys": "@image_key",
             "a_min": -175,
             "a_max": 250,
             "b_min": 0.0,
@@ -88,29 +94,29 @@
     "deepedit_transforms": [
         {
             "_target_": "scripts.transforms.OrientationGuidanceMultipleLabelDeepEditd",
-            "ref_image": "image",
+            "ref_image": "@image_key",
             "label_names": "@label_names"
         },
         {
             "_target_": "AddGuidanceFromPointsDeepEditd",
-            "ref_image": "image",
+            "ref_image": "@image_key",
             "guidance": "guidance",
             "label_names": "@label_names"
         },
         {
             "_target_": "Resized",
-            "keys": "image",
+            "keys": "@image_key",
             "spatial_size": "@spatial_size",
             "mode": "area"
         },
         {
             "_target_": "ResizeGuidanceMultipleLabelDeepEditd",
             "guidance": "guidance",
-            "ref_image": "image"
+            "ref_image": "@image_key"
         },
         {
             "_target_": "AddGuidanceSignalDeepEditd",
-            "keys": "image",
+            "keys": "@image_key",
             "guidance": "guidance",
             "number_intensity_ch": "@number_intensity_ch"
         }
@@ -118,7 +124,7 @@
     "extra_transforms": [
         {
             "_target_": "EnsureTyped",
-            "keys": "image"
+            "keys": "@image_key"
         }
     ],
     "preprocessing": {
@@ -156,7 +162,7 @@
                 "_target_": "Invertd",
                 "keys": "pred",
                 "transform": "@preprocessing",
-                "orig_keys": "image",
+                "orig_keys": "@image_key",
                 "meta_key_postfix": "meta_dict",
                 "nearest_interp": false,
                 "to_tensor": true
@@ -170,7 +176,11 @@
                 "_target_": "SaveImaged",
                 "keys": "pred",
                 "meta_keys": "pred_meta_dict",
-                "output_dir": "@output_dir"
+                "output_dir": "@output_dir",
+                "output_ext": "@output_ext",
+                "output_dtype": "@output_dtype",
+                "output_postfix": "@output_postfix",
+                "separate_folder": "@separate_folder"
             }
         ]
     },

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -28,7 +28,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0",
+    "monai_version": "fc1350aae1de702404189f334ac17fd6f51321d0",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -2,7 +2,7 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
     "version": "0.5.1",
     "changelog": {
-        "0.5.1": "add option to validate at training start",
+        "0.5.1": "add option to validate at training start, and I/O param entries",
         "0.5.0": "enable finetune and early stop",
         "0.4.9": "fix orientation issue on clicks",
         "0.4.8": "Add infer transforms to manage clicks from viewer",

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -28,7 +28,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.3.0rc4",
+    "monai_version": "1.3.0rc5",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.0",
+    "version": "0.5.1",
     "changelog": {
+        "0.5.1": "add option to validate at training start",
         "0.5.0": "enable finetune and early stop",
         "0.4.9": "fix orientation issue on clicks",
         "0.4.8": "Add infer transforms to manage clicks from viewer",

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -28,7 +28,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.2.0",
+    "monai_version": "1.3.0rc4",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -28,7 +28,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "fc1350aae1de702404189f334ac17fd6f51321d0",
+    "monai_version": "1.2.0",
     "pytorch_version": "1.13.1",
     "numpy_version": "1.22.2",
     "optional_packages_version": {

--- a/models/spleen_deepedit_annotation/configs/train.json
+++ b/models/spleen_deepedit_annotation/configs/train.json
@@ -28,6 +28,7 @@
     "deepgrow_probability_train": 0.4,
     "deepgrow_probability_val": 1.0,
     "val_interval": 1,
+    "val_at_start": false,
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
     "network_def": {
         "_target_": "DynUNet",
@@ -324,6 +325,7 @@
                 "_target_": "ValidationHandler",
                 "validator": "@validate#evaluator",
                 "epoch_level": true,
+                "exec_at_start": "@val_at_start",
                 "interval": "@val_interval"
             },
             {


### PR DESCRIPTION
### Description

Modify bundle as the new feature enabled in https://github.com/Project-MONAI/MONAI/commit/fc1350aae1de702404189f334ac17fd6f51321d0

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
