### PR TITLE
Change bundle name in readme [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,12 @@ A basic example to download and extract a bundle is:
 
 ```bash
 pip install "monai[fire]"
-python -m monai.bundle download "wholeBody_ct_segmentation" --bundle_dir "bundles/"
+python -m monai.bundle download "spleen_ct_segmentation" --bundle_dir "bundles/"
 ```
 
-- The commands will download `wholeBody_ct_segmentation` to the current directory's `bundles/` subdirectory.
+- The commands will download `spleen_ct_segmentation` to the current directory's `bundles/` subdirectory.
 - For more downloading options, please run `python -m monai.bundle download -h`
-- For the specific usage of a bundle, please refer to its `docs` folder, for example, `bundles/wholeBody_ct_segmentation/docs`.
+- For the specific usage of a bundle, please refer to its `docs` folder, for example, `bundles/spleen_ct_segmentation/docs`.
 
 To get started with the models, please see [the example use cases](https://github.com/Project-MONAI/tutorials/tree/main/model_zoo).
 


### PR DESCRIPTION
Related to https://github.com/Project-MONAI/MONAI/pull/7280

### Description
Before MONAI 1.3.1 release, we can only download bundles that have all lowercase name. Therefore, this PR is used to change example bundle name in README to avoid potential issues with MONAI 1.3

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
