### PR TITLE
Add `load_pretrain` flag in the reference

### DIFF
--- a/models/brats_mri_segmentation/configs/inference.json
+++ b/models/brats_mri_segmentation/configs/inference.json
@@ -12,6 +12,7 @@
     "output_dtype": "uint8",
     "output_postfix": "seg",
     "separate_folder": true,
+    "load_pretrain": true,
     "data_list_file_path": "$@bundle_root + '/configs/datalist.json'",
     "dataset_dir": "/workspace/data/medical/brats2018challenge",
     "test_datalist": "$monai.data.load_decathlon_datalist(@data_list_file_path, data_list_key='testing', base_dir=@dataset_dir)",
@@ -140,7 +141,7 @@
     },
     "initialize": [
         "$setattr(torch.backends.cudnn, 'benchmark', True)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/brats_mri_segmentation/configs/metadata.json
+++ b/models/brats_mri_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.9",
+    "version": "0.5.0",
     "changelog": {
+        "0.5.0": "add load_pretrain flag for infer",
         "0.4.9": "add checkpoint loader for infer",
         "0.4.8": "fix the wrong GPU index issue of multi-node",
         "0.4.7": "enhance prepare datalist file",

--- a/models/endoscopic_inbody_classification/configs/inference.json
+++ b/models/endoscopic_inbody_classification/configs/inference.json
@@ -7,6 +7,7 @@
     ],
     "bundle_root": ".",
     "image_key": "image",
+    "load_pretrain": true,
     "output_dir": "$@bundle_root + '/eval'",
     "output_filename": "predictions.csv",
     "dataset_dir": "/workspace/data/endoscopic_inbody_classification",
@@ -119,7 +120,7 @@
     },
     "initialize": [
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/endoscopic_inbody_classification/configs/metadata.json
+++ b/models/endoscopic_inbody_classification/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "changelog": {
+        "0.4.7": "add load_pretrain flag for infer",
         "0.4.6": "add output for inference",
         "0.4.5": "update with EnsureChannelFirstd and remove meta dict usage",
         "0.4.4": "fix the wrong GPU index issue of multi-node",

--- a/models/endoscopic_tool_segmentation/configs/inference.json
+++ b/models/endoscopic_tool_segmentation/configs/inference.json
@@ -11,6 +11,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "/workspace/data/endoscopic_tool_dataset",
     "datalist": "$list(sorted(glob.glob(os.path.join(@dataset_dir,'test', '*', '*[!seg].jpg'))))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
@@ -140,7 +141,7 @@
     },
     "initialize": [
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/endoscopic_tool_segmentation/configs/metadata.json
+++ b/models/endoscopic_tool_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.7",
+    "version": "0.5.8",
     "changelog": {
+        "0.5.8": "add load_pretrain flag for infer",
         "0.5.7": "add checkpoint loader for infer",
         "0.5.6": "update to use monai 1.3.0",
         "0.5.5": "update AddChanneld with EnsureChannelFirstd and set image_only to False",

--- a/models/lung_nodule_ct_detection/configs/inference.json
+++ b/models/lung_nodule_ct_detection/configs/inference.json
@@ -16,6 +16,7 @@
     "test_datalist": "$monai.data.load_decathlon_datalist(@data_list_file_path, is_segmentation=True, data_list_key='validation', base_dir=@dataset_dir)",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
     "amp": true,
+    "load_pretrain": true,
     "spatial_dims": 3,
     "num_classes": 1,
     "force_sliding_window": false,
@@ -212,7 +213,7 @@
     },
     "initialize": [
         "$setattr(torch.backends.cudnn, 'benchmark', True)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/lung_nodule_ct_detection/configs/metadata.json
+++ b/models/lung_nodule_ct_detection/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "changelog": {
+        "0.6.3": "add load_pretrain flag for infer",
         "0.6.2": "add checkpoint loader for infer",
         "0.6.1": "fix format error",
         "0.6.0": "remove meta_dict usage",

--- a/models/pancreas_ct_dints_segmentation/configs/inference.yaml
+++ b/models/pancreas_ct_dints_segmentation/configs/inference.yaml
@@ -14,6 +14,7 @@ output_ext: ".nii.gz"
 output_dtype: "$numpy.float32"
 output_postfix: "trans"
 separate_folder: true
+load_pretrain: true
 dataset_dir: "/workspace/data/msd/Task07_Pancreas"
 data_list_file_path: "$@bundle_root + '/configs/dataset_0.json'"
 datalist: "$monai.data.load_decathlon_datalist(@data_list_file_path, data_list_key='testing',
@@ -124,6 +125,6 @@ checkpointloader:
     model: "@network"
 initialize:
 - "$setattr(torch.backends.cudnn, 'benchmark', True)"
-- "$@checkpointloader(@evaluator)"
+- "$@checkpointloader(@evaluator) if @load_pretrain else None"
 run:
 - "$@evaluator.run()"

--- a/models/pancreas_ct_dints_segmentation/configs/metadata.json
+++ b/models/pancreas_ct_dints_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.4.7",
+    "version": "0.4.8",
     "changelog": {
+        "0.4.8": "add load_pretrain flag for infer",
         "0.4.7": "add missing yaml lib requirement in metadata",
         "0.4.6": "add checkpoint loader for infer",
         "0.4.5": "set image_only to False",

--- a/models/pathology_nuclick_annotation/configs/inference.json
+++ b/models/pathology_nuclick_annotation/configs/inference.json
@@ -13,6 +13,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "/workspace/data/CoNSePNuclei",
     "images": "$list(sorted(glob.glob(@dataset_dir + '/Test/Images/*.png')))[:1]",
     "centroids": "$list(sorted(glob.glob(@dataset_dir + '/Test/Centroids/*.txt')))[:1]",
@@ -137,7 +138,7 @@
         "$import sys",
         "$sys.path.append(@bundle_root)",
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/pathology_nuclick_annotation/configs/metadata.json
+++ b/models/pathology_nuclick_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "changelog": {
+        "0.1.8": "add load_pretrain flag for infer",
         "0.1.7": "add checkpoint loader for infer",
         "0.1.6": "set image_only to False",
         "0.1.5": "add support for TensorRT conversion and inference",

--- a/models/spleen_ct_segmentation/configs/inference.json
+++ b/models/spleen_ct_segmentation/configs/inference.json
@@ -11,6 +11,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "/workspace/data/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
@@ -156,7 +157,7 @@
     },
     "initialize": [
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.5",
+    "version": "0.5.6",
     "changelog": {
+        "0.5.6": "add load_pretrain flag for infer",
         "0.5.5": "add checkpoint loader for infer",
         "0.5.4": "update to use monai 1.3.0",
         "0.5.3": "fix the wrong GPU index issue of multi-node",

--- a/models/spleen_deepedit_annotation/configs/inference.json
+++ b/models/spleen_deepedit_annotation/configs/inference.json
@@ -12,6 +12,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "/workspace/Datasets/MSD_datasets/Task09_Spleen",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "label_names": {
@@ -207,7 +208,7 @@
     },
     "initialize": [
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/spleen_deepedit_annotation/configs/metadata.json
+++ b/models/spleen_deepedit_annotation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "changelog": {
+        "0.5.4": "add load_pretrain flag for infer",
         "0.5.3": "update to use monai 1.3.0",
         "0.5.2": "update the checkpoint loader logic for inference",
         "0.5.1": "add option to validate at training start, and I/O param entries",

--- a/models/swin_unetr_btcv_segmentation/configs/inference.json
+++ b/models/swin_unetr_btcv_segmentation/configs/inference.json
@@ -11,6 +11,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "/workspace/data/RawData/",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
@@ -145,7 +146,7 @@
     },
     "initialize": [
         "$monai.utils.set_determinism(seed=123)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/swin_unetr_btcv_segmentation/configs/metadata.json
+++ b/models/swin_unetr_btcv_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "changelog": {
+        "0.5.3": "add load_pretrain flag for infer",
         "0.5.2": "add checkpoint loader for infer",
         "0.5.1": "remove meta_dict usage",
         "0.5.0": "fix the wrong GPU index issue of multi-node",

--- a/models/wholeBody_ct_segmentation/configs/inference.json
+++ b/models/wholeBody_ct_segmentation/configs/inference.json
@@ -16,6 +16,7 @@
     "output_dtype": "$numpy.float32",
     "output_postfix": "trans",
     "separate_folder": true,
+    "load_pretrain": true,
     "dataset_dir": "sampledata",
     "datalist": "$list(sorted(glob.glob(@dataset_dir + '/imagesTs/*.nii.gz')))",
     "device": "$torch.device('cuda:0' if torch.cuda.is_available() else 'cpu')",
@@ -162,7 +163,7 @@
     },
     "initialize": [
         "$setattr(torch.backends.cudnn, 'benchmark', True)",
-        "$@checkpointloader(@evaluator)"
+        "$@checkpointloader(@evaluator) if @load_pretrain else None"
     ],
     "run": [
         "$@evaluator.run()"

--- a/models/wholeBody_ct_segmentation/configs/metadata.json
+++ b/models/wholeBody_ct_segmentation/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "changelog": {
+        "0.2.3": "add load_pretrain flag for infer",
         "0.2.2": "add checkpoint loader for infer",
         "0.2.1": "remove meta_dict usage",
         "0.2.0": "add support for TensorRT conversion and inference",


### PR DESCRIPTION
Follow up https://github.com/Project-MONAI/model-zoo/pull/559 https://github.com/Project-MONAI/model-zoo/pull/561 https://github.com/Project-MONAI/model-zoo/pull/565, here introduced the `load_pretrain` flag. This allows users to decide whether or not to load pre-trained weights when initializing the workflow.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
