### PR TITLE
Support MONAI RC tag in CI without explicitly setting it in bundle metadata and update spleen_segmentation ver

### DIFF
--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -32,10 +32,10 @@ def increment_version(version):
         print(increment_version("1"))      # Expected output: 1.0.1
     """
     version = str(version)
-    parts = version.split('.')
+    parts = version.split(".")
     # Extend the list with zeros to handle cases like "1" or "1.4".
     while len(parts) < 3:
-        parts.append('0')
+        parts.append("0")
 
     # Convert all parts to integers.
     parts = list(map(int, parts))
@@ -45,7 +45,7 @@ def increment_version(version):
 
     # Join the parts back into a version string.
     # This trims trailing '.0's, returning the version in its original format
-    result_version = '.'.join(map(str, parts)).rstrip('.0')
+    result_version = ".".join(map(str, parts)).rstrip(".0")
 
     return result_version
 

--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -12,6 +12,7 @@
 
 import argparse
 import os
+import sys
 
 from bundle_custom_data import install_dependency_dict
 from utils import get_json_dict
@@ -66,7 +67,7 @@ def get_requirements(bundle, models_path):
                 lib_monai_req = f"monai=={monai_version}"
             else:
                 lib_monai_req = f"monai>={monai_version}rc1,<{increment_version(monai_version)}"
-                print(f"ALLOW_MONAI_RC is set to true, the version range is {lib_monai_req}")
+                print(f"ALLOW_MONAI_RC is set to true, the version range is {lib_monai_req}", file=sys.stderr)
             libs.append(lib_monai_req)
         if "pytorch_version" in metadata.keys():
             pytorch_version = metadata["pytorch_version"]

--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -25,7 +25,7 @@ def increment_version(version):
 
     Args:
         version (str): The version string to increment.
-    
+
     Examples:
         print(increment_version("1.3.2"))  # Expected output: 1.3.3
         print(increment_version("1.4"))    # Expected output: 1.4.1
@@ -36,17 +36,17 @@ def increment_version(version):
     # Extend the list with zeros to handle cases like "1" or "1.4".
     while len(parts) < 3:
         parts.append('0')
-    
+
     # Convert all parts to integers.
     parts = list(map(int, parts))
-    
+
     # Increment the last part.
     parts[-1] += 1
-    
+
     # Join the parts back into a version string.
     # This trims trailing '.0's, returning the version in its original format
     result_version = '.'.join(map(str, parts)).rstrip('.0')
-    
+
     return result_version
 
 

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -63,7 +63,7 @@ verify_bundle() {
                 fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pip install "$include_pre_release" -r "$requirements"
+                    pip install $include_pre_release -r "$requirements"
                 fi
                 # verify bundle
                 python $(pwd)/ci/verify_bundle.py -b "$bundle" -m "min"  # min tests on cpu

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=false
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1
@@ -58,10 +58,6 @@ verify_bundle() {
                 # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
                 if [ $ALLOW_MONAI_RC = true ]; then
                     include_pre_release="--pre"
-                    # debug info
-                    if [ ! -z "$requirements" ]; then
-                        cat "$requirements" | grep "monai"
-                    fi
                 else
                     include_pre_release=""
                 fi

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=false
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -20,6 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
+ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1
@@ -54,9 +55,15 @@ verify_bundle() {
                 pip install -r requirements-dev.txt
                 # get required libraries according to the bundle's metadata file
                 requirements=$(python $(pwd)/ci/get_bundle_requirements.py --b "$bundle")
+                # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
+                if [ $ALLOW_MONAI_RC = true ]; then
+                    include_pre_release="--pre"
+                else
+                    include_pre_release=""
+                fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pip install -r "$requirements"
+                    pip install "$include_pre_release" -r "$requirements"
                 fi
                 # verify bundle
                 python $(pwd)/ci/verify_bundle.py -b "$bundle" -m "min"  # min tests on cpu

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -58,6 +58,10 @@ verify_bundle() {
                 # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
                 if [ $ALLOW_MONAI_RC = true ]; then
                     include_pre_release="--pre"
+                    # debug info
+                    if [ ! -z "$requirements" ]; then
+                        cat "$requirements" | grep "monai"
+                    fi
                 else
                     include_pre_release=""
                 fi

--- a/ci/run_premerge_gpu.sh
+++ b/ci/run_premerge_gpu.sh
@@ -70,7 +70,7 @@ verify_bundle() {
                 fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pipenv install "$include_pre_release" -r "$requirements"
+                    pipenv install $include_pre_release -r "$requirements"
                 fi
                 # get extra install script if exists
                 extra_script=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle" --get_script True)

--- a/ci/run_premerge_gpu.sh
+++ b/ci/run_premerge_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_gpu.sh
+++ b/ci/run_premerge_gpu.sh
@@ -20,6 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
+ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1
@@ -61,9 +62,15 @@ verify_bundle() {
                 init_pipenv requirements-dev.txt
                 # get required libraries according to the bundle's metadata file
                 requirements=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle")
+                # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
+                if [ $ALLOW_MONAI_RC = true ]; then
+                    include_pre_release="--pre"
+                else
+                    include_pre_release=""
+                fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pipenv install -r "$requirements"
+                    pipenv install "$include_pre_release" -r "$requirements"
                 fi
                 # get extra install script if exists
                 extra_script=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle" --get_script True)

--- a/ci/run_premerge_gpu.sh
+++ b/ci/run_premerge_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=false
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_gpu.sh
+++ b/ci/run_premerge_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=false
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_multi_gpu.sh
+++ b/ci/run_premerge_multi_gpu.sh
@@ -70,7 +70,7 @@ verify_bundle() {
                 fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pipenv install "$include_pre_release" -r "$requirements"
+                    pipenv install $include_pre_release -r "$requirements"
                 fi
                 # get extra install script if exists
                 extra_script=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle" --get_script True)

--- a/ci/run_premerge_multi_gpu.sh
+++ b/ci/run_premerge_multi_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_multi_gpu.sh
+++ b/ci/run_premerge_multi_gpu.sh
@@ -20,6 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
+ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1
@@ -61,9 +62,15 @@ verify_bundle() {
                 init_pipenv requirements-dev.txt
                 # get required libraries according to the bundle's metadata file
                 requirements=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle")
+                # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
+                if [ $ALLOW_MONAI_RC = true ]; then
+                    include_pre_release="--pre"
+                else
+                    include_pre_release=""
+                fi
                 if [ ! -z "$requirements" ]; then
                     echo "install required libraries for bundle: $bundle"
-                    pipenv install -r "$requirements"
+                    pipenv install "$include_pre_release" -r "$requirements"
                 fi
                 # get extra install script if exists
                 extra_script=$(pipenv run python $(pwd)/ci/get_bundle_requirements.py --b "$bundle" --get_script True)

--- a/ci/run_premerge_multi_gpu.sh
+++ b/ci/run_premerge_multi_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=false
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_premerge_multi_gpu.sh
+++ b/ci/run_premerge_multi_gpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 BUILD_TYPE=all
-export ALLOW_MONAI_RC=false
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     BUILD_TYPE=$1

--- a/ci/run_regular_tests_cpu.sh
+++ b/ci/run_regular_tests_cpu.sh
@@ -48,7 +48,7 @@ verify_release_bundle() {
     fi
     if [ ! -z "$requirements" ]; then
         echo "install required libraries for bundle: $bundle"
-        pip install "$include_pre_release" -r "$requirements"
+        pip install $include_pre_release -r "$requirements"
     fi
     # verify bundle
     python $(pwd)/ci/verify_bundle.py -b "$bundle" -p "$download_path" -m "regular"  # regular tests on cpu

--- a/ci/run_regular_tests_cpu.sh
+++ b/ci/run_regular_tests_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 bundle=""
-export ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=false
 
 if [[ $# -eq 1 ]]; then
     bundle=$1

--- a/ci/run_regular_tests_cpu.sh
+++ b/ci/run_regular_tests_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 bundle=""
-export ALLOW_MONAI_RC=false
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     bundle=$1

--- a/ci/run_regular_tests_cpu.sh
+++ b/ci/run_regular_tests_cpu.sh
@@ -20,7 +20,7 @@
 
 set -ex
 bundle=""
-ALLOW_MONAI_RC=true
+export ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     bundle=$1

--- a/ci/run_regular_tests_cpu.sh
+++ b/ci/run_regular_tests_cpu.sh
@@ -20,6 +20,7 @@
 
 set -ex
 bundle=""
+ALLOW_MONAI_RC=true
 
 if [[ $# -eq 1 ]]; then
     bundle=$1
@@ -39,9 +40,15 @@ verify_release_bundle() {
     python $(pwd)/ci/download_latest_bundle.py --b "$bundle" --models_path $(pwd)/models --p "$download_path"
     # get required libraries according to the bundle's metadata file
     requirements=$(python $(pwd)/ci/get_bundle_requirements.py --b "$bundle" --p "$download_path")
+    # check if ALLOW_MONAI_RC is set to 1, if so, append --pre to the pip install command
+    if [ $ALLOW_MONAI_RC = true ]; then
+        include_pre_release="--pre"
+    else
+        include_pre_release=""
+    fi
     if [ ! -z "$requirements" ]; then
         echo "install required libraries for bundle: $bundle"
-        pip install -r "$requirements"
+        pip install "$include_pre_release" -r "$requirements"
     fi
     # verify bundle
     python $(pwd)/ci/verify_bundle.py -b "$bundle" -p "$download_path" -m "regular"  # regular tests on cpu

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -2,7 +2,8 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
     "version": "0.5.7",
     "changelog": {
-        "0.5.8": "update to use monai 1.3.1",
+        "0.5.8": "update to use monai 1.3.2",
+        "0.5.7": "update to use monai 1.3.1",
         "0.5.6": "add load_pretrain flag for infer",
         "0.5.5": "add checkpoint loader for infer",
         "0.5.4": "update to use monai 1.3.0",

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -35,7 +35,7 @@
         "0.1.0": "complete the model package",
         "0.0.1": "initialize the model package structure"
     },
-    "monai_version": "1.3.1",
+    "monai_version": "1.3.2",
     "pytorch_version": "2.2.2",
     "numpy_version": "1.24.4",
     "optional_packages_version": {

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -2,7 +2,7 @@
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
     "version": "0.5.7",
     "changelog": {
-        "0.5.7": "update to use monai 1.3.1",
+        "0.5.8": "update to use monai 1.3.1",
         "0.5.6": "add load_pretrain flag for infer",
         "0.5.5": "add checkpoint loader for infer",
         "0.5.4": "update to use monai 1.3.0",

--- a/models/spleen_ct_segmentation/configs/metadata.json
+++ b/models/spleen_ct_segmentation/configs/metadata.json
@@ -1,6 +1,6 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20220324.json",
-    "version": "0.5.7",
+    "version": "0.5.8",
     "changelog": {
         "0.5.8": "update to use monai 1.3.2",
         "0.5.7": "update to use monai 1.3.1",


### PR DESCRIPTION
Fixes #595 

### Description

Improve the CI to allow metadata bundle to use future release monai version, if the rc version exists.

### Status
**Work in progress**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.

