### PR TITLE
Benchmark VISTA3D

### DIFF
--- a/models/vista3d/configs/inference.json
+++ b/models/vista3d/configs/inference.json
@@ -15,7 +15,8 @@
     "output_dtype": "$np.float32",
     "output_postfix": "trans",
     "separate_folder": true,
-    "input_dict": "${'image': '/data/Task09_Spleen/imagesTr/spleen_10.nii.gz', 'label_prompt': [3]}",
+    "sw_batch_size": 10,
+    "input_dict": "${'image': '/home/liubin/data/trt_2408/dataset/Task09_Spleen/imagesTr/spleen_10.nii.gz'}",
     "everything_labels": "$list(set([i+1 for i in range(132)]) - set([2,16,18,20,21,23,24,25,26,27,128,129,130,131,132]))",
     "metadata_path": "$@bundle_root + '/configs/metadata.json'",
     "metadata": "$json.loads(pathlib.Path(@metadata_path).read_text())",
@@ -40,7 +41,6 @@
         1.5,
         1.5
     ],
-    "sw_batch_size": 1,
     "patch_size": [
         128,
         128,
@@ -105,9 +105,19 @@
             "dtype": "$torch.float32"
         }
     ],
+    "range_preprocessing": {
+        "_target_": "Range",
+        "name": "preprocessing",
+        "recursive": true
+    },
+    "range_postprocessing": {
+        "_target_": "Range",
+        "name": "postprocessing",
+        "recursive": true
+    },
     "preprocessing": {
         "_target_": "Compose",
-        "transforms": "$@preprocessing_transforms "
+        "transforms": "$@range_preprocessing(@preprocessing_transforms)"
     },
     "dataset": {
         "_target_": "Dataset",
@@ -128,9 +138,7 @@
         "sw_batch_size": "@sw_batch_size",
         "use_point_window": "@use_point_window"
     },
-    "postprocessing": {
-        "_target_": "Compose",
-        "transforms": [
+    "postprocessing_transforms":[
             {
                 "_target_": "ToDeviced",
                 "keys": "pred",
@@ -164,12 +172,23 @@
                 "output_postfix": "@output_postfix",
                 "separate_folder": "@separate_folder"
             }
-        ]
+    ],
+    "postprocessing": {
+        "_target_": "Compose",
+        "transforms": "$@range_postprocessing(@postprocessing_transforms)"
     },
     "handlers": [
         {
             "_target_": "StatsHandler",
             "iteration_log": false
+        },
+        {
+            "_target_": "RangeHandler",
+            "events": "ITERATION"
+        },
+        {
+            "_target_": "RangeHandler",
+            "events": "BATCH"
         }
     ],
     "checkpointloader": {

--- a/models/vista3d/configs/inference.json
+++ b/models/vista3d/configs/inference.json
@@ -138,40 +138,40 @@
         "sw_batch_size": "@sw_batch_size",
         "use_point_window": "@use_point_window"
     },
-    "postprocessing_transforms":[
-            {
-                "_target_": "ToDeviced",
-                "keys": "pred",
-                "device": "cpu",
-                "_disabled_": true
-            },
-            {
-                "_target_": "monai.apps.vista3d.transforms.VistaPostTransformd",
-                "keys": "pred"
-            },
-            {
-                "_target_": "Invertd",
-                "keys": "pred",
-                "transform": "$copy.deepcopy(@preprocessing)",
-                "orig_keys": "@image_key",
-                "nearest_interp": true,
-                "to_tensor": true
-            },
-            {
-                "_target_": "Lambdad",
-                "func": "$lambda x: torch.nan_to_num(x, nan=255)",
-                "keys": "pred"
-            },
-            {
-                "_target_": "SaveImaged",
-                "keys": "pred",
-                "resample": false,
-                "output_dir": "@output_dir",
-                "output_ext": "@output_ext",
-                "output_dtype": "@output_dtype",
-                "output_postfix": "@output_postfix",
-                "separate_folder": "@separate_folder"
-            }
+    "postprocessing_transforms": [
+        {
+            "_target_": "ToDeviced",
+            "keys": "pred",
+            "device": "cpu",
+            "_disabled_": true
+        },
+        {
+            "_target_": "monai.apps.vista3d.transforms.VistaPostTransformd",
+            "keys": "pred"
+        },
+        {
+            "_target_": "Invertd",
+            "keys": "pred",
+            "transform": "$copy.deepcopy(@preprocessing)",
+            "orig_keys": "@image_key",
+            "nearest_interp": true,
+            "to_tensor": true
+        },
+        {
+            "_target_": "Lambdad",
+            "func": "$lambda x: torch.nan_to_num(x, nan=255)",
+            "keys": "pred"
+        },
+        {
+            "_target_": "SaveImaged",
+            "keys": "pred",
+            "resample": false,
+            "output_dir": "@output_dir",
+            "output_ext": "@output_ext",
+            "output_dtype": "@output_dtype",
+            "output_postfix": "@output_postfix",
+            "separate_folder": "@separate_folder"
+        }
     ],
     "postprocessing": {
         "_target_": "Compose",

--- a/models/vista3d/scripts/inferer.py
+++ b/models/vista3d/scripts/inferer.py
@@ -15,6 +15,7 @@ from typing import List, Union
 import torch
 from monai.apps.vista3d.inferer import point_based_window_inferer
 from monai.inferers import Inferer, SlidingWindowInfererAdapt
+from monai.utils import Range
 from torch import Tensor
 
 
@@ -80,38 +81,40 @@ class Vista3dInferer(Inferer):
                 device = inputs[0].device
             else:
                 device = inputs.device
-            val_outputs = point_based_window_inferer(
-                inputs=inputs,
-                roi_size=self.roi_size,
-                sw_batch_size=self.sw_batch_size,
-                transpose=True,
-                with_coord=True,
-                predictor=network,
-                mode="gaussian",
-                sw_device=device,
-                device=device,
-                overlap=self.overlap,
-                point_coords=point_coords,
-                point_labels=point_labels,
-                class_vector=class_vector,
-                prompt_class=prompt_class,
-                prev_mask=prev_mask,
-                labels=labels,
-                label_set=label_set,
-            )
+            with Range("SW_PointInfer"):
+                val_outputs = point_based_window_inferer(
+                    inputs=inputs,
+                    roi_size=self.roi_size,
+                    sw_batch_size=self.sw_batch_size,
+                    transpose=True,
+                    with_coord=True,
+                    predictor=network,
+                    mode="gaussian",
+                    sw_device=device,
+                    device=device,
+                    overlap=self.overlap,
+                    point_coords=point_coords,
+                    point_labels=point_labels,
+                    class_vector=class_vector,
+                    prompt_class=prompt_class,
+                    prev_mask=prev_mask,
+                    labels=labels,
+                    label_set=label_set,
+                )
         else:
-            val_outputs = SlidingWindowInfererAdapt(
-                roi_size=self.roi_size, sw_batch_size=self.sw_batch_size, with_coord=True
-            )(
-                inputs,
-                network,
-                transpose=True,
-                point_coords=point_coords,
-                point_labels=point_labels,
-                class_vector=class_vector,
-                prompt_class=prompt_class,
-                prev_mask=prev_mask,
-                labels=labels,
-                label_set=label_set,
-            )
+            with Range("SW_Infer"):
+                val_outputs = SlidingWindowInfererAdapt(
+                    roi_size=self.roi_size, sw_batch_size=self.sw_batch_size, with_coord=True
+                )(
+                    inputs,
+                    network,
+                    transpose=True,
+                    point_coords=point_coords,
+                    point_labels=point_labels,
+                    class_vector=class_vector,
+                    prompt_class=prompt_class,
+                    prev_mask=prev_mask,
+                    labels=labels,
+                    label_set=label_set,
+                )
         return val_outputs


### PR DESCRIPTION
### Description
This is a function to benchmark, analyze and optimize VISTA3D bundle all class segmentation inference to get a better latency. I will try to add all the benchmark results and analyses in the PR comments. Meanwhile the general conclusion will be updated here in the PR description.

Also need to update the MONAI core code according to [this PR](https://github.com/binliunls/MONAI/pull/1).
### Status
**Work in progress**

### Conclusion
1. A larger sw_batch_size (~14) can optimize the latency on the A100(80GB) GPU. 

### TODO:
- [x] Add timing function to analyze the latency of each part of the bundle.
- [x] Find out the bottleneck of the latency.
- [ ] Analyze the detail latency of each part of the VISTA3D network.
- [ ] Compare the TRT model and non-TRT model.
- [ ] Optimize the latency with the TRT and other methods.
