### PR TITLE
Fix unsupported data dtype for FindContours in vista2d

### DIFF
--- a/models/vista2d/configs/metadata.json
+++ b/models/vista2d/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20240725.json",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "changelog": {
+        "0.2.9": "fix unsupported data dtype in findContours",
         "0.2.8": "remove relative path in readme",
         "0.2.7": "enhance readme",
         "0.2.6": "update tensorrt benchmark results",

--- a/models/vista2d/scripts/components.py
+++ b/models/vista2d/scripts/components.py
@@ -251,6 +251,7 @@ class SaveTiffExd(MapTransform):
                 cv2.imwrite(output_filepath, image)
                 logger.info(f"Overlay Masks: Saving {output_filepath}")
             else:
+                label = cv2.convertScaleAbs(label, alpha=255.0/label.max())
                 contours, _ = cv2.findContours(label, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
                 polygons.extend(self.to_polygons(contours))
 

--- a/models/vista2d/scripts/components.py
+++ b/models/vista2d/scripts/components.py
@@ -251,7 +251,7 @@ class SaveTiffExd(MapTransform):
                 cv2.imwrite(output_filepath, image)
                 logger.info(f"Overlay Masks: Saving {output_filepath}")
             else:
-                label = cv2.convertScaleAbs(label, alpha=255.0/label.max())
+                label = cv2.convertScaleAbs(label, alpha=255.0 / label.max())
                 contours, _ = cv2.findContours(label, cv2.RETR_LIST, cv2.CHAIN_APPROX_SIMPLE)
                 polygons.extend(self.to_polygons(contours))
 


### PR DESCRIPTION
Fixes #677

### Description
Use `cv2.convertScaleAbs` function to scale and convert the label to an 8-bit format then apply find_contours, it will not influence the result of the contours.

### Status
**Ready/Work in progress/Hold**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
