### PR TITLE
re-host github release bundles into HF

### DIFF
--- a/models/brain_image_synthesis_latent_diffusion_model/configs/metadata.json
+++ b/models/brain_image_synthesis_latent_diffusion_model/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20240725.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
+        "1.0.1": "update to huggingface hosting",
         "1.0.0": "Initial release"
     },
     "monai_version": "1.4.0",

--- a/models/cxr_image_synthesis_latent_diffusion_model/configs/metadata.json
+++ b/models/cxr_image_synthesis_latent_diffusion_model/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20240725.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
+        "1.0.1": "update to huggingface hosting",
         "1.0.0": "Initial release"
     },
     "monai_version": "1.4.0",

--- a/models/mednist_ddpm/configs/metadata.json
+++ b/models/mednist_ddpm/configs/metadata.json
@@ -1,7 +1,8 @@
 {
     "schema": "https://github.com/Project-MONAI/MONAI-extra-test-data/releases/download/0.8.1/meta_schema_20240725.json",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "changelog": {
+        "1.0.1": "update to huggingface hosting",
         "1.0.0": "Initial release"
     },
     "monai_version": "1.4.0",

--- a/models/model_info.json
+++ b/models/model_info.json
@@ -1799,18 +1799,6 @@
         "checksum": "95c9552e4bc421d1533872c7cb9d27969cec685f",
         "source": "https://api.ngc.nvidia.com/v2/models/nvidia/monaihosting/maisi_ct_generative/versions/0.4.6/files/maisi_ct_generative_v0.4.6.zip"
     },
-    "cxr_image_synthesis_latent_diffusion_model_v1.0.0": {
-        "checksum": "47b66d3325b582ed23f6583e7f95982424914185",
-        "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/cxr_image_synthesis_latent_diffusion_model_v1.0.0.zip"
-    },
-    "mednist_ddpm_v1.0.0": {
-        "checksum": "e01b9d8b5bfe961ee4b3cfc54bf0574954a84569",
-        "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/mednist_ddpm_v1.0.0.zip"
-    },
-    "brain_image_synthesis_latent_diffusion_model_v1.0.0": {
-        "checksum": "6c39a58e1645c7fec8e433cf21eb39b35c1a900a",
-        "source": "https://github.com/Project-MONAI/model-zoo/releases/download/hosting_storage_v1/brain_image_synthesis_latent_diffusion_model_v1.0.0.zip"
-    },
     "maisi_ct_generative_v1.0.0": {
         "checksum": "",
         "source": "https://huggingface.co/MONAI/maisi_ct_generative/tree/1.0.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 monai>=1.0.1
+huggingface_hub==0.29.3


### PR DESCRIPTION
Fixes # .

### Description
This PR can be used to:
1) test new huggingface hosting (after PR: https://github.com/Project-MONAI/model-zoo/pull/735 merge)
2) remove workaround github release hosting.

After this PR is merged, I will make changes in MONAI to modify the bundle download logic 

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).
