### PR TITLE
Add description metadata to model info

### DIFF
--- a/ci/update_model_info_deparate.py
+++ b/ci/update_model_info_deparate.py
@@ -84,10 +84,11 @@ def update_model_info(
     model_info = get_json_dict(model_info_path)
 
     if bundle_name_with_version not in model_info.keys():
-        model_info[bundle_name_with_version] = {"checksum": "", "source": ""}
+        model_info[bundle_name_with_version] = {"checksum": "", "source": "", "description": ""}
 
     model_info[bundle_name_with_version]["checksum"] = checksum
     model_info[bundle_name_with_version]["source"] = source
+    model_info[bundle_name_with_version]["description"] = metadata["description"]
 
     save_model_info(model_info, model_info_path)
     return (True, "update successful")

--- a/ci/update_model_info_deparate_ngc.py
+++ b/ci/update_model_info_deparate_ngc.py
@@ -94,10 +94,11 @@ def update_model_info(
 
     # step 4
     if bundle_name_with_version not in model_info.keys():
-        model_info[bundle_name_with_version] = {"checksum": "", "source": ""}
+        model_info[bundle_name_with_version] = {"checksum": "", "source": "", "description": ""}
 
     model_info[bundle_name_with_version]["checksum"] = checksum
     model_info[bundle_name_with_version]["source"] = source
+    model_info[bundle_name_with_version]["description"] = metadata["description"]
 
     save_model_info(model_info, model_info_path)
     return (True, "update successful")


### PR DESCRIPTION
### Description
This PR adds the description metadata to the model info file, as described in the issue #770  

The rationale is to have access to more information about the available model when using https://api.github.com/repos/Project-MONAI/model-zoo/releases/tags/hosting_storage_v1

Please let me know your thought, and if this is the right approach to solve this issue.

### Status
**Ready**


