### PR TITLE
[ENH] Skip premerge CPU tests for documentation-only bundle changes

### DIFF
--- a/ci/get_changed_bundle.py
+++ b/ci/get_changed_bundle.py
@@ -15,28 +15,28 @@ import argparse
 from utils import get_changed_bundle_list
 
 
-def get_changed_bundle(changed_dirs):
+def get_changed_bundle(changed_dirs, filter_docs=False):
     """
     This function is used to get all changed bundles, a string which
     contains all bundle names will be printed, and can be used in shell scripts.
     """
     bundle_names = ""
     root_path = "models"
-    bundle_list = get_changed_bundle_list(changed_dirs, root_path=root_path)
+    bundle_list = get_changed_bundle_list(changed_dirs, root_path=root_path, filter_docs=filter_docs)
 
     for bundle in bundle_list:
         bundle_names += f"{bundle} "
     print(bundle_names)
 
 
-def get_changed_hf_model(changed_dirs):
+def get_changed_hf_model(changed_dirs, filter_docs=False):
     """
     This function is used to get all changed hf models, a string which
     contains all hf model names will be printed, and can be used in shell scripts.
     """
     hf_model_names = ""
     root_path = "hf_models"
-    hf_model_list = get_changed_bundle_list(changed_dirs, root_path=root_path)
+    hf_model_list = get_changed_bundle_list(changed_dirs, root_path=root_path, filter_docs=filter_docs)
     for hf_model in hf_model_list:
         hf_model_names += f"{hf_model} "
     print(hf_model_names)
@@ -46,9 +46,12 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("-f", "--f", type=str, help="changed files.")
     parser.add_argument("--hf_model", type=bool, default=False, help="if true, get changed hf models.")
+    parser.add_argument(
+        "--filter_docs", type=bool, default=False, help="if true, skip bundles with documentation-only changes."
+    )
     args = parser.parse_args()
     changed_dirs = args.f.splitlines()
     if args.hf_model:
-        get_changed_hf_model(changed_dirs)
+        get_changed_hf_model(changed_dirs, filter_docs=args.filter_docs)
     else:
-        get_changed_bundle(changed_dirs)
+        get_changed_bundle(changed_dirs, filter_docs=args.filter_docs)

--- a/ci/get_changed_bundle.py
+++ b/ci/get_changed_bundle.py
@@ -45,9 +45,9 @@ def get_changed_hf_model(changed_dirs, filter_docs=False):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="")
     parser.add_argument("-f", "--f", type=str, help="changed files.")
-    parser.add_argument("--hf_model", type=bool, default=False, help="if true, get changed hf models.")
+    parser.add_argument("--hf_model", action="store_true", help="if true, get changed hf models.")
     parser.add_argument(
-        "--filter_docs", type=bool, default=False, help="if true, skip bundles with documentation-only changes."
+        "--filter_docs", action="store_true", help="if true, skip bundles with documentation-only changes."
     )
     args = parser.parse_args()
     changed_dirs = args.f.splitlines()

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -87,7 +87,7 @@ verify_bundle() {
     if [ ! -z "$changes" ]
     then
         # get all changed bundles
-        bundle_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$changes" --filter_docs True)
+        bundle_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$changes" --filter_docs)
         if [ ! -z "$bundle_list" ]
         then
             python $(pwd)/ci/prepare_schema.py --l "$bundle_list"
@@ -128,7 +128,7 @@ verify_bundle() {
     if [ ! -z "$hf_model_changes" ]
     then
         # get all changed hf models
-        hf_model_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$hf_model_changes" --hf_model True --filter_docs True)
+        hf_model_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$hf_model_changes" --hf_model --filter_docs)
         if [ ! -z "$hf_model_list" ]
         then
             python $(pwd)/ci/prepare_schema.py --l "$hf_model_list" --p "hf_models"

--- a/ci/run_premerge_cpu.sh
+++ b/ci/run_premerge_cpu.sh
@@ -87,7 +87,7 @@ verify_bundle() {
     if [ ! -z "$changes" ]
     then
         # get all changed bundles
-        bundle_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$changes")
+        bundle_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$changes" --filter_docs True)
         if [ ! -z "$bundle_list" ]
         then
             python $(pwd)/ci/prepare_schema.py --l "$bundle_list"
@@ -128,7 +128,7 @@ verify_bundle() {
     if [ ! -z "$hf_model_changes" ]
     then
         # get all changed hf models
-        hf_model_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$hf_model_changes" --hf_model True)
+        hf_model_list=$(python $(pwd)/ci/get_changed_bundle.py --f "$hf_model_changes" --hf_model True --filter_docs True)
         if [ ! -z "$hf_model_list" ]
         then
             python $(pwd)/ci/prepare_schema.py --l "$hf_model_list" --p "hf_models"

--- a/ci/utils.py
+++ b/ci/utils.py
@@ -26,6 +26,26 @@ Github, _ = optional_import("github", name="Github")
 
 SUPPORTED_HASH_TYPES = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256, "sha512": hashlib.sha512}
 
+# Documentation file patterns that do not require code testing
+DOC_DIR_NAME = "docs"
+DOC_FILE_EXTENSIONS = {".md"}
+
+
+def is_doc_file(filepath: str) -> bool:
+    """
+    Check if a file is a documentation file that does not require code testing.
+
+    A file is considered documentation if it is inside a ``docs/`` directory
+    or has a documentation-only extension (e.g. ``.md``).
+    """
+    parts = filepath.replace("\\", "/").split("/")
+    if DOC_DIR_NAME in parts:
+        return True
+    _, ext = os.path.splitext(filepath)
+    if ext.lower() in DOC_FILE_EXTENSIONS:
+        return True
+    return False
+
 
 def get_sub_folders(root_dir: str):
     """
@@ -49,12 +69,20 @@ def get_hash_func(hash_type: str = "sha1"):
     return actual_hash_func()
 
 
-def get_changed_bundle_list(changed_dirs: List[str], root_path: str = "models"):
+def get_changed_bundle_list(changed_dirs: List[str], root_path: str = "models", filter_docs: bool = False):
     """
     This function is used to return all bundle names that have changed files.
     If a bundle is totally removed, it will be ignored (since it not exists).
 
+    If ``filter_docs`` is True, changed files that are documentation-only
+    (inside a ``docs/`` directory or with a ``.md`` extension) are excluded
+    before determining which bundles have changed.  A bundle whose changes
+    are **all** documentation files will therefore not appear in the
+    returned list.
     """
+    if filter_docs:
+        changed_dirs = [d for d in changed_dirs if not is_doc_file(d)]
+
     bundles = get_sub_folders(root_path)
 
     changed_bundle_list = []


### PR DESCRIPTION
Closes #756.

### Description
When a pull request only modifies documentation files inside a bundle (files in a `docs/` directory or with a `.md` extension), the premerge CPU test suite now skips that bundle entirely. If a bundle has both documentation and code changes, it is still tested as usual.

**Changes:**
- `ci/utils.py`: add `is_doc_file()` helper and a `filter_docs` parameter to `get_changed_bundle_list()`. Documentation files are defined as files inside a `docs/` directory or with a `.md` extension.
- `ci/get_changed_bundle.py`: expose `--filter_docs` as a CLI argument, propagated to both `get_changed_bundle()` and `get_changed_hf_model()`.
- `ci/run_premerge_cpu.sh`: pass `--filter_docs True` to both `get_changed_bundle.py` calls (regular bundles and HuggingFace models).

The `filter_docs` parameter defaults to `False`, so weekly tests and Blossom CI are not affected.

### Status
Ready

### Please ensure all the checkboxes:
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [x] In-line docstrings updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI premerge checks updated to optionally ignore documentation-only changes when detecting changed bundles or models, reducing false-positive verifications for doc-only edits.
  * Command-line tooling enhanced with flags to select HF model mode and to enable/disable documentation filtering for change detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->