### PR TITLE
Fixing Requirements File Generation

### DIFF
--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -83,7 +83,13 @@ def get_requirements(bundle, models_path, requirements_file):
                 for name, version in optional_dict.items():
                     if name in special_dependencies_list:
                         continue
-                    libs.append(f"{name}=={version}")
+
+                    version = version.strip()
+                    version_line = f"{name}=={version}"
+                    if version[0] in {"<", ">", "="}:  # operator included in version, don't add ==
+                        version_line = f"{name}{version}"
+
+                    libs.append(version_line)
 
         if len(libs) > 0:
             with open(requirements_file, "w") as f:

--- a/ci/get_bundle_requirements.py
+++ b/ci/get_bundle_requirements.py
@@ -77,19 +77,22 @@ def get_requirements(bundle, models_path, requirements_file):
         if "numpy_version" in metadata.keys():
             numpy_version = metadata["numpy_version"]
             libs.append(f"numpy=={numpy_version}")
+
         for package_key in ["optional_packages_version", "required_packages_version"]:
-            if package_key in metadata.keys():
-                optional_dict = metadata[package_key]
-                for name, version in optional_dict.items():
-                    if name in special_dependencies_list:
-                        continue
+            for name, version in metadata.get(package_key, {}).items():
+                if name in special_dependencies_list:
+                    continue
 
-                    version = version.strip()
-                    version_line = f"{name}=={version}"
-                    if version[0] in {"<", ">", "="}:  # operator included in version, don't add ==
-                        version_line = f"{name}{version}"
+                version = version.strip()
 
-                    libs.append(version_line)
+                if not version:  # blank version, just add name without version specification
+                    version_line = str(name)
+                elif version[0] in {"<", ">", "=", "!", "~"}:  # operator included in version, don't add ==
+                    version_line = f"{name}{version}"
+                else:
+                    version_line = f"{name}=={version}"  # assume exact version specification
+
+                libs.append(version_line)
 
         if len(libs) > 0:
             with open(requirements_file, "w") as f:


### PR DESCRIPTION
### Description
This allows requirements files to be generated at test time from version in bundles which include range specifiers, eg "foo": ">=1.2.3". The bundle specification does not precisely say what the version specification should be thus it should be compatible with pip-style version specifiers of this format. 

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bundle dependency requirement formatting.
  * Version strings are now trimmed of extra whitespace.
  * If a package version is blank, only the package name is emitted (no version constraint).
  * If a version already starts with an operator (for example `<`, `>`, `=`, `!`, `~`), it’s preserved without adding redundant `==`.
  * Produces cleaner, more accurate generated dependency specifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->