### PR TITLE
Remove Fuzzy Gdown Argument

### DIFF
--- a/ci/utils.py
+++ b/ci/utils.py
@@ -129,7 +129,6 @@ def download_large_files(bundle_path: str, large_file_name: str = "large_file.ym
     parser.read_config(os.path.join(bundle_path, large_file_name))
     large_files_list = parser.get()["large_files"]
     for lf_data in large_files_list:
-        lf_data["fuzzy"] = True
         if "hash_val" in lf_data and lf_data.get("hash_val", "") == "":
             lf_data.pop("hash_val")
         if "hash_type" in lf_data and lf_data.get("hash_type", "") == "":

--- a/ci/utils_deparate.py
+++ b/ci/utils_deparate.py
@@ -95,7 +95,6 @@ def download_large_files(bundle_path: str, large_file_name: str = "large_file.ym
     parser.read_config(os.path.join(bundle_path, large_file_name))
     large_files_list = parser.get()["large_files"]
     for lf_data in large_files_list:
-        lf_data["fuzzy"] = True
         if "hash_val" in lf_data and lf_data.get("hash_val", "") == "":
             lf_data.pop("hash_val")
         if "hash_type" in lf_data and lf_data.get("hash_type", "") == "":

--- a/ci/utils_deparate_ngc.py
+++ b/ci/utils_deparate_ngc.py
@@ -24,6 +24,8 @@ from monai.utils import look_up_option, optional_import
 
 Github, _ = optional_import("github", name="Github")
 
+gdown, has_gdown = optional_import("gdown")
+
 SUPPORTED_HASH_TYPES = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256, "sha512": hashlib.sha512}
 
 
@@ -98,7 +100,6 @@ def download_large_files(bundle_path: str, large_file_name: str = "large_file.ym
     parser.read_config(os.path.join(bundle_path, large_file_name))
     large_files_list = parser.get()["large_files"]
     for lf_data in large_files_list:
-        lf_data["fuzzy"] = True
         if "hash_val" in lf_data and lf_data.get("hash_val", "") == "":
             lf_data.pop("hash_val")
         if "hash_type" in lf_data and lf_data.get("hash_type", "") == "":

--- a/ci/utils_deparate_ngc.py
+++ b/ci/utils_deparate_ngc.py
@@ -24,8 +24,6 @@ from monai.utils import look_up_option, optional_import
 
 Github, _ = optional_import("github", name="Github")
 
-gdown, has_gdown = optional_import("gdown")
-
 SUPPORTED_HASH_TYPES = {"md5": hashlib.md5, "sha1": hashlib.sha1, "sha256": hashlib.sha256, "sha512": hashlib.sha512}
 
 


### PR DESCRIPTION
### Description
This removes the now deprecated gdown "fuzzy" argument. This has found to be a breaking issue for running the CI for new bundles.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [ ] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [ ] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [ ] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [ ] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted large-file download handling to use the provided file details as-is, improving consistency when fetching files.
  * Streamlined download processing with no visible change to the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->