### PR TITLE
Add inference_rocm.json for wholeBody_ct_segmentation

### DIFF
--- a/models/wholeBody_ct_segmentation/configs/inference_rocm.json
+++ b/models/wholeBody_ct_segmentation/configs/inference_rocm.json
@@ -1,0 +1,13 @@
+{
+    "+imports": [
+        "$import torch"
+    ],
+    "network": "$@network_def.to(@device).to(memory_format=torch.channels_last_3d)",
+    "initialize": [
+        "$monai.utils.set_determinism(seed=123)",
+        "$setattr(torch.backends.cudnn, 'deterministic', False)",
+        "$setattr(@evaluator, 'amp_kwargs', {'dtype': torch.bfloat16})",
+        "$@checkpointloader(@evaluator) if @load_pretrain else None",
+        "$setattr(@evaluator, 'network', torch.compile(@network))"
+    ]
+}


### PR DESCRIPTION
### Description
Adds inference_rocm.json overlay for wholeBody_ct_segmentation to enable optimized inference on AMD ROCm GPUs. The overlay applies NHWC memory layout (channels_last_3d), and torch.compile on top of the existing inference.json — no changes to base configs, weights, or metadata.

### Status
**Ready**

### Please ensure all the checkboxes:
<!--- Put an `x` in all the boxes that apply, and remove the not applicable items -->
- [x] Codeformat tests passed locally by running `./runtests.sh --codeformat`.
- [ ] In-line docstrings updated.
- [ ] Update `version` and `changelog` in `metadata.json` if changing an existing bundle.
- [x] Please ensure the naming rules in config files meet our requirements (please refer to: `CONTRIBUTING.md`).
- [x] Ensure versions of packages such as `monai`, `pytorch` and `numpy` are correct in `metadata.json`.
- [ ] Descriptions should be consistent with the content, such as `eval_metrics` of the provided weights and TorchScript modules.
- [x] Files larger than 25MB are excluded and replaced by providing download links in `large_file.yml`.
- [x] Avoid using path that contains personal information within config files (such as use `/home/your_name/` for `"bundle_root"`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new ROCm inference configuration for whole-body CT segmentation.
  * Improved GPU-side inference setup with optimized precision and compiled execution for better performance and compatibility on supported hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->